### PR TITLE
Uses a different random number seed for a different rank

### DIFF
--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -134,6 +134,9 @@ if is_master:
     else:
         print("seed from command line: %d" % (args.seed))
 args = comm.bcast(args, root = master)
+args.seed += rank
+print ("Rank %d seed: %d" %(rank, args.seed))
+
 
 nt = int(round(args.duration / args.dt))
 stations = np.loadtxt(args.station_file, ndmin = 1, \


### PR DESCRIPTION
This is to avoid all processes using the same random seed and effectively producing similar random patterns for stations. 

If we have more processes than a number of stations, each process computes one station (or no station), and as a result, all stations showed very similar result due to using the same random sequence. 

This fix can mitigate the problem by adding "rank" to the "seed", forcing every rank to produce different random sequence. 