### PR TITLE
Bug fix for install.py

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -343,8 +343,7 @@ def action(
     site_v1d_dir=None,
     hf_stat_vs_ref=None,
     v1d_full_path=None,
-    sim_params_file='',
-    dt=default_dt
+    sim_params_file="",
 ):
     lf_sim_root_dir = os.path.join(sim_dir, "LF")
     hf_dir = os.path.join(sim_dir, "HF")


### PR DESCRIPTION
This line was removed in https://github.com/ucgmsim/slurm_gm_workflow/pull/48/files as the dt value is not used anymore as it now comes out of the yaml params. The default constant was therefore also removed.

The line was re-added in PR https://github.com/ucgmsim/slurm_gm_workflow/pull/51/files and since the default constant is gone this currently breaks on install.