### PR TITLE
added vsref to bb in root_defaults.yaml

### DIFF
--- a/templates/gmsim/16.1/root_defaults.yaml
+++ b/templates/gmsim/16.1/root_defaults.yaml
@@ -10,6 +10,7 @@ bb:
   site_specific: false
   fmin: 0.2
   fmidbot: 0.5
+  lfvsref: 500.0
 emod3d:
    emod3d_version: 3.0.4
 flo: 0.25


### PR DESCRIPTION
Default behaviour without this is lfvsref = None so it will use lfvsref values obtained from 3DVM.
This addition of lfvsref = 500.0 makes this consistent with "conventional" Graves and Pitarka (where it previously just used vsref = 500 for both LF and HF).
Have tested this on maui and seems to work.