### PR TITLE
bb_sim and hf_sim now only parse known args. Any extras are ignored.

### DIFF
--- a/estimation/estimate_cybershake.py
+++ b/estimation/estimate_cybershake.py
@@ -300,7 +300,7 @@ def get_runs_dir_params(
             os.path.join(runs_dir, fault_name, r, "sim_params.yaml")
         )
 
-        data.append((params.dt, params.hf.hf_dt, params.FD_STATLIST, params.hf.hf_slip))
+        data.append((params.dt, params.hf.dt, params.FD_STATLIST, params.hf.slip))
 
     return np.rec.array(
         data,
@@ -422,7 +422,7 @@ def main(args):
         )
 
         # Calculate nt
-        r_hf_nt = np.repeat(fault_sim_durations / runs_params.hf_dt, r_counts)
+        r_hf_nt = np.repeat(fault_sim_durations / runs_params.dt, r_counts)
 
         hf_input_data = np.concatenate(
             (

--- a/metadata/log_metadata.py
+++ b/metadata/log_metadata.py
@@ -230,18 +230,18 @@ def main(args):
     # HF
     elif args.proc_type == ProcessType.HF.str_value:
         metadata_dict[MetadataField.nt.value] = int(
-            float(params.sim_duration) / float(params.hf.hf_dt)
+            float(params.sim_duration) / float(params.hf.dt)
         )
         metadata_dict[MetadataField.nsub_stoch.value] = get_nsub_stoch(
             params["hf"]["hf_slip"], get_area=False
         )
     # BB
     elif args.proc_type == ProcessType.BB.str_value:
-        metadata_dict[MetadataField.dt.value] = params.hf.hf_dt
+        metadata_dict[MetadataField.dt.value] = params.hf.dt
     # IM_calc
     elif args.proc_type == ProcessType.IM_calculation.str_value:
         metadata_dict[MetadataField.nt.value] = int(
-            float(params.sim_duration) / float(params.hf.hf_dt)
+            float(params.sim_duration) / float(params.hf.dt)
         )
         # This should come from a constants file
         im_calc_csv_file = os.path.join(

--- a/scripts/bb_sim.py
+++ b/scripts/bb_sim.py
@@ -49,7 +49,7 @@ if is_master:
     )
 
     try:
-        args = parser.parse_args()
+        args = parser.parse_known_args()[0]
     except SystemExit:
         # invalid arguments or -h
         comm.Abort()

--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -51,7 +51,7 @@ if is_master:
     parser = ArgumentParser()
     arg = parser.add_argument
     # HF IN, line 12
-    arg("stoch_file", help="rupture model")
+    arg("--hf_slip", required=True, dest="stoch_file", help="rupture model")
     # HF IN, line 2
     arg("station_file", help="station file (lon, lat, name)")
     # HF IN, line 3

--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -82,7 +82,7 @@ if is_master:
     # HF IN, line 7
     arg(
         "--seed",
-        help="random seed (0:randomised reproducable, -1:fully randomised)",
+        help="random seed (0:randomised reproducible, -1:fully randomised)",
         type=int,
         default=5481190,
     )
@@ -148,7 +148,7 @@ if is_master:
         default=1,
     )
     try:
-        args = parser.parse_args()
+        args = parser.parse_known_args()[0]
     except SystemExit:
         # invalid arguments or -h
         comm.Abort()

--- a/scripts/set_runparams.py
+++ b/scripts/set_runparams.py
@@ -84,6 +84,14 @@ def create_run_params(sim_dir, srf_name=None, workflow_config=None, steps_per_ch
         e3d_dict['stat_file'] = params.stat_file
         e3d_dict['grid_file'] = params.GRIDFILE
         e3d_dict['model_params'] = params.MODEL_PARAMS
+
+        if params.emod3d:
+            for key, value in params.emod3d.items():
+                if key in e3d_dict:
+                    e3d_dict[key] = value
+                else:
+                    print("{} not found as a key in e3d file. Ignoring variable. Value is {}.".format(key, value))
+
         shared.write_to_py(os.path.join(params.sim_dir, 'LF', 'e3d.par'), e3d_dict)
 
 

--- a/scripts/set_runparams.py
+++ b/scripts/set_runparams.py
@@ -30,7 +30,7 @@ def create_run_params(sim_dir, srf_name=None, workflow_config=None, steps_per_ch
         workflow_config = load_config.load(
             os.path.dirname(os.path.realpath(__file__)), "workflow_config.json")
     global_root = workflow_config["global_root"]
-    tools_dir = binary_version.get_lf_bin(params.emod3d.emod3d_version)
+    tools_dir = binary_version.get_lf_bin(params.emod3d.version)
     emod3d_version = workflow_config["emod3d_version"]
 
     e3d_yaml = os.path.join(workflow_config['templates_dir'], 'gmsim', params.version, 'emod3d_defaults.yaml')

--- a/scripts/submit_bb.py
+++ b/scripts/submit_bb.py
@@ -132,7 +132,7 @@ def main(args):
             wct = default_wct
         else:
             # Use HF nt for wct estimation
-            nt = int(float(params.sim_duration) / float(params.hf.hf_dt))
+            nt = int(float(params.sim_duration) / float(params.hf.dt))
             fd_count = len(shared.get_stations(params.FD_STATLIST))
 
             est_core_hours, est_run_time = wc.est_BB_chours_single(fd_count, nt, ncores)

--- a/scripts/submit_bb.py
+++ b/scripts/submit_bb.py
@@ -46,18 +46,11 @@ def write_sl_script(
             "--flo",
             str(params.flo),
         ]
-        additional_args = ["fmin", "fmidbot", "lfvsref"]
-        for key in additional_args:
-            if key in params.bb:
-                arguments.append("--" + key)
-                arguments.append(str(params.bb[key]))
-
-        additional_flags = ["no-lf-amp"]
-        for key in additional_flags:
-            if key in params.bb:
-                # seperated intentionally so the key will not be incerted when it is not there before.
-                if params.bb[key] is True:
-                    arguments.append("--" + key)
+        for key in params.bb:
+            arguments.append("--" + key)
+            if params.bb[key] is True:
+                continue
+            arguments.append(str(params.bb[key]))
         bb_submit_command = submit_command + " ".join(arguments)
     else:
         bb_submit_command = (

--- a/scripts/submit_emod3d.py
+++ b/scripts/submit_emod3d.py
@@ -115,7 +115,7 @@ def main(args):
         target_qconfig = get_machine_config(args.machine)
 
         binary_path = binary_version.get_lf_bin(
-            params.emod3d.emod3d_version, target_qconfig["tools_dir"]
+            params.emod3d.version, target_qconfig["tools_dir"]
         )
         steps_per_checkpoint = int(
             get_nt(params)

--- a/scripts/submit_hf.py
+++ b/scripts/submit_hf.py
@@ -54,10 +54,10 @@ def write_sl_script(
             "--duration",
             params.sim_duration,
             "--dt",
-            params.hf.hf_dt,
+            params.hf.dt,
             "--sim_bin",
             binary_version.get_hf_binmod(
-                params.hf.hf_version, target_qconfig["tools_dir"]
+                params.hf.version, target_qconfig["tools_dir"]
             ),
         ]
 
@@ -163,12 +163,12 @@ def main(args):
     # if srf(variation) is provided as args, only create
     # the slurm with same name provided
     if args.srf is None or srf_name == args.srf:
-        nt = int(float(params.sim_duration) / float(params.hf.hf_dt))
+        nt = int(float(params.sim_duration) / float(params.hf.dt))
         fd_count = len(shared.get_stations(params.FD_STATLIST))
         # TODO:make it read through the whole list
         #  instead of assuming every stoch has same size
         nsub_stoch, sub_fault_area = srf.get_nsub_stoch(
-            params.hf.hf_slip, get_area=True
+            params.hf.slip, get_area=True
         )
 
         if args.debug:

--- a/scripts/submit_hf.py
+++ b/scripts/submit_hf.py
@@ -47,7 +47,6 @@ def write_sl_script(
             create_dir + "srun python $gmsim/workflow" "/scripts/hf_sim.py "
         )
         arguments_for_hf = [
-            params.hf.hf_slip,
             params.FD_STATLIST,
             os.path.join(hf_sim_dir, "Acc/HF.bin"),
             "-m",

--- a/scripts/submit_hf.py
+++ b/scripts/submit_hf.py
@@ -61,11 +61,10 @@ def write_sl_script(
                 params.hf.hf_version, target_qconfig["tools_dir"]
             ),
         ]
-        additional_args = ["hf_path_dur"]
-        for key in additional_args:
-            if key in params.hf:
-                arguments_for_hf.append("--" + key)
-                arguments_for_hf.append(str(params.hf[key]))
+
+        for key in params.hf:
+            arguments_for_hf.append("--" + key)
+            arguments_for_hf.append(str(params.hf[key]))
         hf_submit_command += " ".join(list(map(str, arguments_for_hf)))
     else:
         hf_submit_command = (

--- a/scripts/submit_sim_imcalc.py
+++ b/scripts/submit_sim_imcalc.py
@@ -80,7 +80,7 @@ def submit_im_calc_slurm(sim_dir: str, options_dict: Dict = None):
     print("Running wall clock estimation for IM sim")
     est_core_hours, est_run_time = est_IM_chours_single(
         len(shared.get_stations(params.FD_STATLIST)),
-        int(float(params.sim_duration) / float(params.hf.hf_dt)),
+        int(float(params.sim_duration) / float(params.hf.dt)),
         [options_dict[SlBodyOptConsts.component.value]],
         100 if options_dict[SlBodyOptConsts.extended.value] else 15,
         options_dict[SlBodyOptConsts.n_procs.value],

--- a/shared_workflow/install_shared.py
+++ b/shared_workflow/install_shared.py
@@ -197,8 +197,12 @@ def install_simulation(
     if sim_params_file and os.path.isfile(sim_params_file):
         with open(sim_params_file) as spf:
             extra_sims_params = yaml.load(spf)
-        for key in extra_sims_params.keys():
-            sim_params_dict.update({key: extra_sims_params[key]})
+        for key, value in extra_sims_params.items():
+            # If the key exists in both dictionaries and maps to a dictionary in both, then merge them
+            if isinstance(value, dict) and key in sim_params_dict and isinstance(sim_params_dict[key], dict):
+                sim_params_dict[key].update(value)
+            else:
+                sim_params_dict.update({key: value})
 
     return root_params_dict, fault_params_dict, sim_params_dict, vm_params_dict
 

--- a/shared_workflow/shared.py
+++ b/shared_workflow/shared.py
@@ -709,7 +709,7 @@ def get_hf_run_name(v_mod_1d_name, srf, root_dict, hf_version):
     hf_run_name = "{}_{}_rvf{}_sd{}_k{}".format(
         v_mod_1d_name,
         hfVString,
-        str(root_dict["hf"]["hf_rvfac"]),
+        str(root_dict["hf"]["rvfac"]),
         str(root_dict["hf"]["sdrop"]),
         str(root_dict["hf"]["kappa"]),
     )
@@ -717,7 +717,7 @@ def get_hf_run_name(v_mod_1d_name, srf, root_dict, hf_version):
     show_horizontal_line()
     print("- Vel. Model 1D: %s" % v_mod_1d_name)
     print("- hf_sim_bin: %s" % os.path.basename(hf_sim_bin))
-    print("- hf_rvfac: %s" % root_dict["hf"]["hf_rvfac"])
+    print("- hf_rvfac: %s" % root_dict["hf"]["rvfac"])
     print("- hf_sdrop: %s" % root_dict["hf"]["sdrop"])
     print("- hf_kappa: %s" % root_dict["hf"]["kappa"])
     print("- srf file: %s" % srf)

--- a/templates/gmsim/16.1/root_defaults.yaml
+++ b/templates/gmsim/16.1/root_defaults.yaml
@@ -1,17 +1,17 @@
 hf:
-  hf_version: 5.4.5
-  hf_dt: 0.005
-  hf_rvfac: 0.8
-  hf_sdrop: 50
-  hf_path_dur: 1
-  hf_kappa: 0.045
+  version: 5.4.5
+  dt: 0.005
+  rvfac: 0.8
+  sdrop: 50
+  path_dur: 1
+  kappa: 0.045
 bb:
-  bb_version: 3.0.4
+  version: 3.0.4
   site_specific: false
   fmin: 0.2
   fmidbot: 0.5
   lfvsref: 500.0
 emod3d:
-   emod3d_version: 3.0.4
+  version: 3.0.4
 flo: 0.25
 dt: 0.02


### PR DESCRIPTION
All settings in params.bb and params.hf are now added as parameters in
their respective slurm scripts
On install all settings under the hf and bb key of the sim_params yaml
are added to the sim_params.yaml file in the realisation directory