### PR TITLE
Remove Checkpoint folder before clean up happens.

### DIFF
--- a/scripts/clean_up.py
+++ b/scripts/clean_up.py
@@ -12,7 +12,6 @@ import argparse
 from qcore import utils
 
 SUBMISSION_DIR_NAME = "submission_temp"
-SUBMISSION_SUBDIR_NAME = "slurm_and_logs"
 SUBMISSION_TAR = "submission.tar"
 SUBMISSION_FILES = [
     "flist_LF",
@@ -71,7 +70,7 @@ def move_files(sim_dir, dest_dir, file_patterns):
                 )
 
 
-def create_temp_dirs(sim_dir, outer_dir_name, inner_dir_name):
+def create_temp_dirs(sim_dir, outer_dir_name, inner_dir_name=''):
     """
     creates two nested temp dirs containing files to be tared
     :param sim_dir: path to realization folder
@@ -80,9 +79,11 @@ def create_temp_dirs(sim_dir, outer_dir_name, inner_dir_name):
     :return: paths to outer_dir and inner dir
     """
     outer_dir = os.path.join(sim_dir, outer_dir_name)
-    inner_dir = os.path.join(sim_dir, outer_dir_name, inner_dir_name)
     utils.setup_dir(outer_dir)
-    utils.setup_dir(inner_dir)
+    inner_dir = ''
+    if inner_dir_name is not '':
+        inner_dir = os.path.join(sim_dir, outer_dir_name, inner_dir_name)
+        utils.setup_dir(inner_dir)
     return outer_dir, inner_dir
 
 
@@ -95,27 +96,25 @@ def clean_up_submission_lf_files(
     :param lf_files_to_tar: a list of additional lf related files to tar
     :return: creates submisson and lf tar.gz
     """
-    submission_files_to_tar += SUBMISSION_FILES
+    submission_files_to_tar += SUBMISSION_FILES+SUBMISSION_SL_LOGS
     lf_files_to_tar += LF_FILES
 
     # create temporary submission dir
-    submission_dir, submission_sub_dir = create_temp_dirs(
-        sim_dir, SUBMISSION_DIR_NAME, SUBMISSION_SUBDIR_NAME
+    submission_dir, _ = create_temp_dirs(
+        sim_dir, SUBMISSION_DIR_NAME
     )
 
     # create temporary lf dir
     lf_dir, lf_sub_dir = create_temp_dirs(sim_dir, LF_DIR_NAME, LF_SUB_DIR_NAME)
 
-    # move files to submisson dir
+    # move files to submission dir
     move_files(sim_dir, submission_dir, submission_files_to_tar)
-    # copy sl and err logs to submiison sub dir
-    move_files(sim_dir, submission_sub_dir, SUBMISSION_SL_LOGS)
 
     tar_files(submission_dir, os.path.join(sim_dir, SUBMISSION_TAR))
 
     # move files to lf dir
     move_files(os.path.join(sim_dir, "LF"), lf_dir, lf_files_to_tar)
-    # copy e3d segemnts to lf sub dir
+    # copy e3d segments to lf sub dir
     e3d_segs_dir = os.path.join(sim_dir, "LF", "OutBin")
     for f in os.listdir(e3d_segs_dir):
         if "-" in f:  # e3d segments have '-' in the name

--- a/scripts/clean_up.sl
+++ b/scripts/clean_up.sl
@@ -26,7 +26,7 @@ start_time=`date +${runtime_fmt}`
 echo ___cleaning up___
 
 python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up running
-
+rm -r $SIM_DIR/LF/Restart
 res=`python $gmsim/workflow/scripts/clean_up.py $SIM_DIR`
 exit_val=$?
 
@@ -35,6 +35,7 @@ echo $end_time
 
 if [[ $exit_val == 0 ]]; then
     #passed
+
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up completed
 
     #save meta data


### PR DESCRIPTION
Don't nest the slurm scripts inside a folder, the top level should be
empty now that the templates are not copied over for each realisation.