### PR TITLE
Backup failed binaries

### DIFF
--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -35,4 +35,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
+    mkdir "$nobackup/tmp/BB_{{srf_name}}_$start_time"
+    mv {{sim_dir}}/LF/* "$nobackup/tmp/BB_{{srf_name}}_$start_time"
 fi

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -35,7 +35,7 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
-    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_BB"
+    backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_BB"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory
     mv {{sim_dir}}/BB/* $backup_directory

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -35,6 +35,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
-    mkdir "$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
-    mv {{sim_dir}}/BB/* "$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
+    echo "Completion test failed, moving all files to $backup_directory"
+    mkdir $backup_directory
+    mv {{sim_dir}}/BB/* $backup_directory
 fi

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -36,5 +36,5 @@ else
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
     mkdir "$nobackup/tmp/BB_{{srf_name}}_$start_time"
-    mv {{sim_dir}}/LF/* "$nobackup/tmp/BB_{{srf_name}}_$start_time"
+    mv {{sim_dir}}/BB/* "$nobackup/tmp/BB_{{srf_name}}_$start_time"
 fi

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -35,8 +35,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
-    backup_directory="$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_BB"
     echo "Completion test failed, moving all files to $backup_directory"
-    mkdir $backup_directory
+    mkdir -p $backup_directory
     mv {{sim_dir}}/BB/* $backup_directory
 fi

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -35,6 +35,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
-    mkdir "$nobackup/tmp/BB_{{srf_name}}_$start_time"
-    mv {{sim_dir}}/BB/* "$nobackup/tmp/BB_{{srf_name}}_$start_time"
+    mkdir "$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
+    mv {{sim_dir}}/BB/* "$nobackup/tmp/BB_{{srf_name}}_$SLURM_JOB_ID"
 fi

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -38,6 +38,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
-    mkdir "$nobackup/tmp/EMOD3D_{{srf_name}}_$SLURM_JOB_ID"
-    mv {{sim_dir}}/LF/* "$nobackup/tmp/EMOD3D_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/LF_{{srf_name}}_$SLURM_JOB_ID"
+    echo "Completion test failed, moving all files to $backup_directory"
+    mkdir $backup_directory
+    mv {{sim_dir}}/LF/* $backup_directory
 fi

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -38,6 +38,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
+    mkdir "$nobackup/tmp/EMOD3D_{{srf_name}}_$start_time"
+    mv {{sim_dir}}/LF/* "$nobackup/tmp/EMOD3D_{{srf_name}}_$start_time"
 fi
-
-

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -38,7 +38,7 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
-    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_LF"
+    backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_LF"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory
     mv {{sim_dir}}/LF/* $backup_directory

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -38,8 +38,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
-    backup_directory="$nobackup/tmp/LF_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_LF"
     echo "Completion test failed, moving all files to $backup_directory"
-    mkdir $backup_directory
+    mkdir -p $backup_directory
     mv {{sim_dir}}/LF/* $backup_directory
 fi

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -38,6 +38,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
-    mkdir "$nobackup/tmp/EMOD3D_{{srf_name}}_$start_time"
-    mv {{sim_dir}}/LF/* "$nobackup/tmp/EMOD3D_{{srf_name}}_$start_time"
+    mkdir "$nobackup/tmp/EMOD3D_{{srf_name}}_$SLURM_JOB_ID"
+    mv {{sim_dir}}/LF/* "$nobackup/tmp/EMOD3D_{{srf_name}}_$SLURM_JOB_ID"
 fi

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -35,6 +35,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
-    mkdir "$nobackup/tmp/HF_{{srf_name}}_$start_time"
-    mv {{sim_dir}}/HF/* "$nobackup/tmp/HF_{{srf_name}}_$start_time"
+    mkdir "$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
+    mv {{sim_dir}}/HF/* "$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
 fi

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -35,4 +35,6 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
+    mkdir "$nobackup/tmp/HF_{{srf_name}}_$start_time"
+    mv {{sim_dir}}/LF/* "$nobackup/tmp/HF_{{srf_name}}_$start_time"
 fi

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -35,6 +35,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
-    mkdir "$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
-    mv {{sim_dir}}/HF/* "$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
+    echo "Completion test failed, moving all files to $backup_directory"
+    mkdir $backup_directory
+    mv {{sim_dir}}/HF/* $backup_directory
 fi

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -35,7 +35,7 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
-    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_HF"
+    backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_HF"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory
     mv {{sim_dir}}/HF/* $backup_directory

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -35,8 +35,8 @@ else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
-    backup_directory="$nobackup/tmp/HF_{{srf_name}}_$SLURM_JOB_ID"
+    backup_directory="$nobackup/tmp/$USER/$SLURM_JOB_ID_{{srf_name}}_HF"
     echo "Completion test failed, moving all files to $backup_directory"
-    mkdir $backup_directory
+    mkdir -p $backup_directory
     mv {{sim_dir}}/HF/* $backup_directory
 fi

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -36,5 +36,5 @@ else
     res=`echo $res | tr -d '\n'`
     python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
     mkdir "$nobackup/tmp/HF_{{srf_name}}_$start_time"
-    mv {{sim_dir}}/LF/* "$nobackup/tmp/HF_{{srf_name}}_$start_time"
+    mv {{sim_dir}}/HF/* "$nobackup/tmp/HF_{{srf_name}}_$start_time"
 fi


### PR DESCRIPTION
Tested to work.
Places the contents of the entire BB/HF/LF folder in $nobackup/tmp/$USER/$job_id_$realisation_$job_type if the completion test fails
This means you need to use submit.sh/auto_submit.py to resubmit the task, not just sbatch the slurm script again
Has been tested