### PR TITLE
added type error exception for none chours data & extended timeout

### DIFF
--- a/dashboard/DashboardDB.py
+++ b/dashboard/DashboardDB.py
@@ -102,7 +102,7 @@ class DashboardDB:
     ):
         """Updates daily and total core hours usage"""
         # daily usage will be None if total is None
-        if total_ch_usage is None:
+        if daily_ch_usage is None or total_ch_usage is None:
             return
 
         table = self.get_daily_t_name(hpc)

--- a/dashboard/run_dashboard_app.py
+++ b/dashboard/run_dashboard_app.py
@@ -492,14 +492,14 @@ def get_maui_daily_quota_string(file_system):
 
 
 def check_update_time(last_update_time_string: str, current_update_time: datetime):
-    """Checks whether the time gap between update times exceeds the idling time limit(300s)
+    """Checks whether the time gap between update times exceeds the idling time limit(1500s)
     if exceeds, regards as a collection error.
     """
     # 2019-03-28 18:31:11.906576
     return (
         current_update_time
         - datetime.strptime(last_update_time_string, "%Y-%m-%d %H:%M:%S.%f")
-    ) < timedelta(seconds=300)
+    ) < timedelta(seconds=1500)
 
 
 def validate_period(start_string, end_string):

--- a/dashboard/run_data_collection.py
+++ b/dashboard/run_data_collection.py
@@ -269,7 +269,7 @@ class DataCollector:
             return 0
         except ValueError:
             print("Failed to convert total core hours to integer.")
-       
+
     def _parse_quota(self, lines: Iterable[str]):
         """
         Gets quota usage from cmd and return as a list of QuotaEntry objects
@@ -366,7 +366,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--update_interval",
         help="Interval between data collection (seconds)",
-        default=30,
+        default=300,
     )
     parser.add_argument(
         "--hpc",

--- a/dashboard/run_data_collection.py
+++ b/dashboard/run_data_collection.py
@@ -131,7 +131,6 @@ class DataCollector:
             "sreport -n -t Hours cluster AccountUtilizationByUser Accounts={} start={} end={}".format(
                 PROJECT_ID, start_time, end_time
             ),
-            timeout=60,
         )
         rt_daily_ch = self.parse_chours_usage(rt_daily_ch_output)
 
@@ -140,7 +139,6 @@ class DataCollector:
             "sreport -n -t Hours cluster AccountUtilizationByUser Accounts={} start={} end={}".format(
                 PROJECT_ID, self.total_start_time, end_time
             ),
-            timeout=60,
         )
         rt_total_ch = self.parse_chours_usage(rt_total_ch_output)
 
@@ -196,7 +194,7 @@ class DataCollector:
                 hpc, self.parse_user_chours_usage(user_ch_output, users)
             )
 
-    def run_cmd(self, hpc: str, cmd: str, timeout: int = 60):
+    def run_cmd(self, hpc: str, cmd: str, timeout: int = 120):
         """Runs the specified command remotely on the specified hpc using the
         specified user id.
         Returns False if the command fails for some reason.
@@ -271,6 +269,8 @@ class DataCollector:
             return 0
         except ValueError:
             print("Failed to convert total core hours to integer.")
+        except TypeError:
+            print("No chours usage data available")
 
     def _parse_quota(self, lines: Iterable[str]):
         """

--- a/dashboard/run_data_collection.py
+++ b/dashboard/run_data_collection.py
@@ -270,7 +270,7 @@ class DataCollector:
         except ValueError:
             print("Failed to convert total core hours to integer.")
         except TypeError:
-            print("No chours usage data available")
+            print("No core hours usage data available")
 
     def _parse_quota(self, lines: Iterable[str]):
         """

--- a/dashboard/run_data_collection.py
+++ b/dashboard/run_data_collection.py
@@ -132,7 +132,8 @@ class DataCollector:
                 PROJECT_ID, start_time, end_time
             ),
         )
-        rt_daily_ch = self.parse_chours_usage(rt_daily_ch_output)
+        if rt_daily_ch_output:
+            rt_daily_ch_output = self.parse_chours_usage(rt_daily_ch_output)
 
         rt_total_ch_output = self.run_cmd(
             hpc.value,
@@ -140,12 +141,11 @@ class DataCollector:
                 PROJECT_ID, self.total_start_time, end_time
             ),
         )
-        rt_total_ch = self.parse_chours_usage(rt_total_ch_output)
-
         if rt_total_ch_output:
-            self.dashboard_db.update_chours_usage(rt_daily_ch, rt_total_ch, hpc)
-        # Squeue, formatted to show full account name
+            rt_total_ch_output = self.parse_chours_usage(rt_total_ch_output)
+            self.dashboard_db.update_chours_usage(rt_daily_ch_output, rt_total_ch_output, hpc)
 
+        # Squeue, formatted to show full account name
         sq_output = self.run_cmd(
             hpc.value, "squeue --format=%18i%25u%12a%60j%20T%25r%20S%18M%18L%10D%10C"
         )
@@ -194,7 +194,7 @@ class DataCollector:
                 hpc, self.parse_user_chours_usage(user_ch_output, users)
             )
 
-    def run_cmd(self, hpc: str, cmd: str, timeout: int = 120):
+    def run_cmd(self, hpc: str, cmd: str, timeout: int = 180):
         """Runs the specified command remotely on the specified hpc using the
         specified user id.
         Returns False if the command fails for some reason.
@@ -269,9 +269,7 @@ class DataCollector:
             return 0
         except ValueError:
             print("Failed to convert total core hours to integer.")
-        except TypeError:
-            print("No core hours usage data available")
-
+       
     def _parse_quota(self, lines: Iterable[str]):
         """
         Gets quota usage from cmd and return as a list of QuotaEntry objects


### PR DESCRIPTION
2019-06-04 12:05:04.594923 - Collecting data from HPC [<HPC.maui: 'maui'>, <HPC.mahuika: 'mahuika'>]
The timeout of 60 expired for cmd sreport -n -t Hours cluster AccountUtilizationByUser Accounts=nesi00213 start=01/06/18-12:00:00 end=06/04/19-12:00:00.
Traceback (most recent call last):
  File "run_data_collection.py", line 389, in <module>
    main(args)
  File "run_data_collection.py", line 358, in main
    data_col.run(args.users)
  File "run_data_collection.py", line 97, in run
    self.collect_data(hpc, users)
  File "run_data_collection.py", line 145, in collect_data
    rt_total_ch = self.parse_chours_usage(rt_total_ch_output)
  File "run_data_collection.py", line 268, in parse_chours_usage
    return ch_lines[0].strip().split()[-2]
TypeError: 'NoneType' object is not subscriptable
