### PR TITLE
changed pip install to dev mode; added Cython to mahuika requirements

### DIFF
--- a/install_workflow/create_env.sh
+++ b/install_workflow/create_env.sh
@@ -70,7 +70,7 @@ fi
 xargs -n 1 -a ${env_path}/workflow/install_workflow/maui_python3_requirements.txt pip install
 
 # Install qcore & Empirical Engine
-pip install -I --no-deps ./qcore
-pip install -I --no-deps ./Empirical_Engine
-pip install -I --no-deps ./IM_calculation
+pip install -I --no-deps -e ./qcore
+pip install -I --no-deps -e ./Empirical_Engine
+pip install -I --no-deps -e ./IM_calculation
 

--- a/install_workflow/create_python_virtenv_mahuika.sh
+++ b/install_workflow/create_python_virtenv_mahuika.sh
@@ -26,6 +26,6 @@ fi
 xargs -n 1 -a ${env_path}/workflow/install_workflow/mahuika_python3_requirements.txt pip install
 
 # Install qcore
-pip install ./qcore
-pip install ./Empirical_Engine
-pip install -I --no-deps ./IM_calculation
+pip install -e ./qcore
+pip install -e ./Empirical_Engine
+pip install -I --no-deps -e ./IM_calculation

--- a/install_workflow/mahuika_python3_requirements.txt
+++ b/install_workflow/mahuika_python3_requirements.txt
@@ -26,3 +26,4 @@ tensorflow==1.12.0
 termcolor==1.1.0
 Werkzeug==0.14.1
 numba==0.43.1
+Cython==0.29.2


### PR DESCRIPTION
 When installing environment on hpc, instead of deploying qcore/Im_calc/emprical_enigne etc into site packages, deploy their git version so that code is up-to-date without keeping 2 copies
eg. import qcore
     qcore.__file__  == /nesi/project/nesi00213/Environments/melody/qcore/qcore/_init__.py