### PR TITLE
fix im_calc compeletion check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Slurm Ground Motion Workflow
 # Changelog
 (Based on https://wiki.canterbury.ac.nz/download/attachments/58458136/CodeVersioning_v18p2.pdf?version=1&modificationDate=1519269238437&api=v2 )
 
+## [19.6.8] - 2019-08-12 -- Fixed IM_calculation compeletion check
+### Changed
+    - fixed logic bug checking compeletion of IM_calculation
+
 ## [19.6.7] - 2019-08-07 -- Add HF log aggregation
 ### Added
     - Added a script to aggregate HF logs into a csv with the amount of core hours lost to thread idling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@ Slurm Ground Motion Workflow
 # Changelog
 (Based on https://wiki.canterbury.ac.nz/download/attachments/58458136/CodeVersioning_v18p2.pdf?version=1&modificationDate=1519269238437&api=v2 )
 
-## [19.6.8] - 2019-08-12 -- Fixed IM_calculation compeletion check
+## [19.6.8] - 2019-08-12 -- Fixed IM_calculation completion check
 ### Changed
-    - fixed logic bug checking compeletion of IM_calculation
+    - fixed logic bug checking completion of IM_calculation
 
 ## [19.6.7] - 2019-08-07 -- Add HF log aggregation
 ### Added

--- a/scripts/submit_sim_imcalc.py
+++ b/scripts/submit_sim_imcalc.py
@@ -138,7 +138,7 @@ def submit_im_calc_slurm(
             "fault_name": fault_name,
             "np": options_dict[SlBodyOptConsts.n_procs.value],
             "output_csv": sim_struct.get_IM_csv(sim_dir),
-            "output_info": sim_struct.get_IM_info(sim_dir)
+            "output_info": sim_struct.get_IM_info(sim_dir),
         },
     )
     script_prefix = "sim_im_calc"
@@ -256,3 +256,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args)
+

--- a/scripts/submit_sim_imcalc.py
+++ b/scripts/submit_sim_imcalc.py
@@ -137,9 +137,10 @@ def submit_im_calc_slurm(
             "sim_name": sim_name,
             "fault_name": fault_name,
             "np": options_dict[SlBodyOptConsts.n_procs.value],
+            "output_csv": sim_struct.get_IM_csv(sim_dir),
+            "output_info": sim_struct.get_IM_info(sim_dir)
         },
     )
-
     script_prefix = "sim_im_calc"
     script_file_path = write_sl_script(
         options_dict["write_directory"],

--- a/scripts/submit_sim_imcalc.py
+++ b/scripts/submit_sim_imcalc.py
@@ -256,4 +256,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args)
-

--- a/templates/sim_im_calc.sl.template
+++ b/templates/sim_im_calc.sl.template
@@ -35,7 +35,7 @@ fi
 
 # Check that the result files exist
 res=0
-if [[ -f {{sim_dir}}/IM_calc/{{sim_name}}.csv ]] && [[ -f {{sim_dir}}/IM_calc/{{sim_name}}_im_calc.info ]]; then
+if [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}.csv ]] && [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}_im_calc.info ]]; then
     res=1
     echo "IM calculation failed, result files do not exist."
 fi

--- a/templates/sim_im_calc.sl.template
+++ b/templates/sim_im_calc.sl.template
@@ -35,7 +35,7 @@ fi
 
 # Check that the result files exist
 res=0
-if [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}.csv ]] && [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}_im_calc.info ]]; then
+if [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}.csv ]] || [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}_im_calc.info ]]; then
     res=1
     echo "IM calculation failed, result files do not exist."
 fi

--- a/templates/sim_im_calc.sl.template
+++ b/templates/sim_im_calc.sl.template
@@ -35,7 +35,7 @@ fi
 
 # Check that the result files exist
 res=0
-if [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}.csv ]] || [[ ! -f {{sim_dir}}/IM_calc/{{sim_name}}_im_calc.info ]]; then
+if [[ ! -f {{output_csv}} ]] || [[ ! -f {{output_info}} ]]; then
     res=1
     echo "IM calculation failed, result files do not exist."
 fi


### PR DESCRIPTION
fixed im_calc completion check.
The reason that im_calc is shown "completed" in mgmt_db even there's runtime error is due to the missing of "not" in im_calc template when checking output file existence.

