### PR TITLE
Changed get_queued_tasks to raise an exception if a valid response is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@ Slurm Ground Motion Workflow
 # Changelog
 (Based on https://wiki.canterbury.ac.nz/download/attachments/58458136/CodeVersioning_v18p2.pdf?version=1&modificationDate=1519269238437&api=v2 )
 
-
+## [19.6.11] - 2019-08-21 -- Squeue failure detection
+### Changed
+    - If squeue does not return the expected headers, it is assumed to have failed. In this case no jobs will be marked as failed and requiring resubmitting
+    - add_to_mgmt_queue now optionally takes in the slurm job id. If it is given it is used to match the update with an existing database entry, if it is not given the user is warned and the update is applied anyway
+    - If more than one entry in the database is updated by an update the user is alerted to this
 
 ## [19.6.10] - 2019-08-16 -- Improved load balancing for HF calculation
 ### Changed

--- a/scripts/calc_rrups_single.sl
+++ b/scripts/calc_rrups_single.sl
@@ -43,7 +43,7 @@ then
     echo ___calculating rrups___
 
     start_time=`date +${runtime_fmt}`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup running
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup running $SLURM_JOB_ID
 
     time python ${IMPATH}/calculate_rrups_single.py -fd ${FD} -o ${OUT_DIR}/rrup_${REL_NAME}.csv ${STATION_FILE} ${SRF_FILE}
 else
@@ -55,7 +55,7 @@ if [[ -f ${OUT_DIR}/rrup_${REL_NAME}.csv ]]
 then
     if [[ $(wc -l < ${OUT_DIR}/rrup_${REL_NAME}.csv) == $(( $(wc -l < ${FD}) + 1)) ]]
     then
-        python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup completed
+        python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup completed $SLURM_JOB_ID
     else
         res="Not enough rrups for the station file"
     fi
@@ -65,7 +65,7 @@ fi
 
 if [[ -n ${res} ]]
 then
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup failed --error '$res'
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup failed $SLURM_JOB_ID --error '$res'
 fi
 
 date

--- a/scripts/clean_up.sl
+++ b/scripts/clean_up.sl
@@ -25,7 +25,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 start_time=`date +${runtime_fmt}`
 echo ___cleaning up___
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up running $SLURM_JOB_ID
 rm -r $SIM_DIR/LF/Restart
 res=`python $gmsim/workflow/scripts/clean_up.py $SIM_DIR`
 exit_val=$?
@@ -36,11 +36,11 @@ echo $end_time
 if [[ $exit_val == 0 ]]; then
     #passed
 
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up completed $SLURM_JOB_ID
 
     #save meta data
     python $gmsim/workflow/metadata/log_metadata.py $SIM_DIR clean_up start_time=$start_time end_time=$end_time
 
 else
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME clean_up failed $SLURM_JOB_ID --error "$res"
 fi

--- a/scripts/cybershake/add_to_mgmt_queue.py
+++ b/scripts/cybershake/add_to_mgmt_queue.py
@@ -23,6 +23,13 @@ if __name__ == "__main__":
         choices=list(const.Status.iterate_str_values()),
     )
     parser.add_argument(
+        "job_id",
+        type=int,
+        nargs="?",
+        help="The job id. Used for setting on job queueing, used for matching on following steps",
+        default=None,
+    )
+    parser.add_argument(
         "--error",
         type=str,
         help="Errors that occurred during the execution of the script.",
@@ -34,5 +41,6 @@ if __name__ == "__main__":
         args.run_name,
         const.ProcessType.from_str(args.proc_type).value,
         const.Status.from_str(args.status).value,
+        job_id=args.job_id,
         error=args.error,
     )

--- a/scripts/cybershake/auto_submit.py
+++ b/scripts/cybershake/auto_submit.py
@@ -360,7 +360,7 @@ def run_main_submit_loop(
                     user=user, machine=hpc
                 )
             except EnvironmentError as e:
-                logger.critical(e)
+                main_logger.critical(e)
                 n_tasks_to_run[hpc] = 0
             else:
                 n_tasks_to_run[hpc] = n_runs[hpc] - len(squeued_tasks)
@@ -465,8 +465,7 @@ def run_main_submit_loop(
     main_logger.info("Nothing was running or ready to run last cycle, exiting now")
 
 
-if __name__ == "__main__":
-
+def main():
     logger = qclogging.get_logger()
 
     parser = argparse.ArgumentParser()
@@ -622,3 +621,7 @@ if __name__ == "__main__":
         (lf_est_model, hf_est_model, bb_est_model, im_est_model),
         main_logger=logger,
     )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/cybershake/auto_submit.py
+++ b/scripts/cybershake/auto_submit.py
@@ -623,5 +623,5 @@ def main():
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/cybershake/queue_monitor.py
+++ b/scripts/cybershake/queue_monitor.py
@@ -324,5 +324,5 @@ def main():
     queue_monitor_loop(root_folder, args.sleep_time, args.n_max_retries, logger)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/cybershake/queue_monitor.py
+++ b/scripts/cybershake/queue_monitor.py
@@ -62,6 +62,7 @@ def update_tasks(
     mgmt_queue_entries: List[str],
     squeue_tasks: Dict[str, str],
     db_running_tasks: List[SlurmTask],
+    complete_data: bool,
     task_logger: Logger,
 ):
     """Updates the mgmt db entries based on the HPC queue"""
@@ -134,23 +135,29 @@ def update_tasks(
             db_running_task.proc_type,
             logger=task_logger,
         ):
-            task_logger.warning(
-                "Task '{}' on '{}' not found on squeue or in the management db folder; resetting the status "
-                "to 'created' for resubmission".format(
-                    const.ProcessType(db_running_task.proc_type).str_value,
-                    db_running_task.run_name,
+            if not complete_data:
+                task_logger.warning(
+                    "Task '{}' not found on squeue or in the management db folder, "
+                    "but errors were encountered when querying squeue. Not resubmitting."
                 )
-            )
-            # Add an error
-            tasks_to_do.append(
-                SlurmTask(
-                    db_running_task.run_name,
-                    db_running_task.proc_type,
-                    const.Status.failed.value,
-                    None,
-                    "Disappeared from squeue. Creating a new task.",
+            else:
+                task_logger.warning(
+                    "Task '{}' on '{}' not found on squeue or in the management db folder; resetting the status "
+                    "to 'created' for resubmission".format(
+                        const.ProcessType(db_running_task.proc_type).str_value,
+                        db_running_task.run_name,
+                    )
                 )
-            )
+                # Add an error
+                tasks_to_do.append(
+                    SlurmTask(
+                        db_running_task.run_name,
+                        db_running_task.proc_type,
+                        const.Status.failed.value,
+                        None,
+                        "Disappeared from squeue. Creating a new task.",
+                    )
+                )
     return tasks_to_do
 
 
@@ -169,16 +176,28 @@ def main(
 
     sqlite_tmpdir = "/tmp/cer"
     while keepAlive:
+        complete_data = True
         if not os.path.exists(sqlite_tmpdir):
             os.makedirs(sqlite_tmpdir)
             queue_logger.debug("Set up the sqlite_tmpdir")
 
         # For each hpc get a list of job id and status', and for each pair save them in a dictionary
-        squeue_tasks = {
-            task.split()[0]: task.split()[1]
-            for hpc in const.HPC
-            for task in get_queued_tasks(machine=hpc)
-        }
+        squeue_tasks = {}
+        for hpc in const.HPC:
+            try:
+                squeued_tasks = get_queued_tasks(machine=hpc)
+            except EnvironmentError as e:
+                logger.critical(e)
+                logger.critical(
+                    "An error was encountered when attempting to check squeue for HPC {}. "
+                    "Tasks will not be submitted to this HPC until the issue is resolved".format(
+                        hpc
+                    )
+                )
+                complete_data = False
+            else:
+                for task in squeued_tasks:
+                    squeue_tasks[task.split()[0]] = task.split()[1]
 
         if len(squeue_tasks) > 0:
             queue_logger.info(
@@ -226,7 +245,13 @@ def main(
                 entries.insert(0, entry)
 
         entries.extend(
-            update_tasks(entry_files, squeue_tasks, db_in_progress_tasks, queue_logger)
+            update_tasks(
+                entry_files,
+                squeue_tasks,
+                db_in_progress_tasks,
+                complete_data,
+                queue_logger,
+            )
         )
 
         if len(entries) > 0:

--- a/scripts/cybershake/run_cybershake.py
+++ b/scripts/cybershake/run_cybershake.py
@@ -128,7 +128,7 @@ def run_automated_workflow(
     queue_monitor_thread = threading.Thread(
         name="queue monitor",
         daemon=True,
-        target=queue_monitor.main,
+        target=queue_monitor.queue_monitor_loop,
         args=(root_folder, sleep_time, n_max_retries, queue_logger),
     )
     wrapper_logger.info("Created queue_monitor thread")

--- a/scripts/hf2bb.sl
+++ b/scripts/hf2bb.sl
@@ -32,7 +32,7 @@ if [[ ! -d $MGMT_DB_LOC/mgmt_db_queue ]]; then
     mkdir $MGMT_DB_LOC/mgmt_db_queue
 fi
 timestamp=`date +%Y%m%d_%H%M%S`
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB running $SLURM_JOB_ID
 
 runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
@@ -49,7 +49,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 res=`$gmsim/workflow/scripts/test_bb.sh $REL_LOC `
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB completed $SLURM_JOB_ID
 
     if [[ ! -d $REL_LOC/ch_log ]]; then
         mkdir $REL_LOC/ch_log
@@ -62,5 +62,5 @@ if [[ $? == 0 ]]; then
 else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME HF2BB failed $SLURM_JOB_ID --error "$res"
 fi

--- a/scripts/im_plot.sl
+++ b/scripts/im_plot.sl
@@ -31,7 +31,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 start_time=`date +${runtime_fmt}`
 echo ___im plot___
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot running $SLURM_JOB_ID
 res=`python $gmsim/visualization/visualization/im_plotting/im_plot.py $CSV_PATH $STATION_FILE_PATH --output $OUTPUT_XYZ_DIR`
 
 exit_val=$?
@@ -94,13 +94,13 @@ if [[ $exit_val == 0 ]]; then
         echo "srf_file $SRF_PATH"
         echo "model_params $MODEL_PARAMS"
         printf '%s\n' "${success_msgs[@]}" 
-        python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot completed
+        python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot completed $SLURM_JOB_ID
     else
        printf '%s\n' "${failed_msgs[@]}" 
-       python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot failed --error "$failed_msgs" 
+       python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot failed $SLURM_JOB_ID --error "$failed_msgs"
     fi
 else
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME IM_plot failed $SLURM_JOB_ID --error "$res"
 fi
 
 end_time=`date +$runtime_fmt`

--- a/scripts/lf2bb.sl
+++ b/scripts/lf2bb.sl
@@ -33,7 +33,7 @@ if [[ ! -d $MGMT_DB_LOC/mgmt_db_queue ]]; then
     mkdir $MGMT_DB_LOC/mgmt_db_queue
 fi
 timestamp=`date +%Y%m%d_%H%M%S`
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB running $SLURM_JOB_ID
 
 runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
@@ -50,7 +50,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 res=`$gmsim/workflow/scripts/test_bb.sh $REL_LOC `
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB completed $SLURM_JOB_ID
 
     if [[ ! -d $REL_LOC/ch_log ]]; then
         mkdir $REL_LOC/ch_log
@@ -63,5 +63,5 @@ if [[ $? == 0 ]]; then
 else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME LF2BB failed $SLURM_JOB_ID --error "$res"
 fi

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -284,7 +284,7 @@ class MgmtDB:
         """Updates all fields that have a value for the specific entry"""
         if entry.status == const.Status.queued.value:
             logger.debug(
-                "Got entry {} with status created. Setting status and job id in the db".format(
+                "Got entry {} with status queued. Setting status and job id in the db".format(
                     entry
                 )
             )

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -325,7 +325,11 @@ class MgmtDB:
                 (entry.status, entry.run_name, entry.proc_type, entry.status),
             )
         if cur.rowcount > 1:
-            logger.warning("Last database update caused {} entries to be updated".format(cur.rowcount))
+            logger.warning(
+                "Last database update caused {} entries to be updated".format(
+                    cur.rowcount
+                )
+            )
         if entry.error is not None:
             cur.execute(
                 """INSERT INTO error (task_id, error)

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -81,7 +81,7 @@ class MgmtDB:
                     logger.debug("New task added to the db, continuing to next process")
                     continue
                 logger.debug("Updating task in the db")
-                self._update_entry(cur, entry)
+                self._update_entry(cur, entry, logger=logger)
                 logger.debug("Task successfully updated")
 
                 if (
@@ -278,17 +278,54 @@ class MgmtDB:
         logger.debug("{} has remaining deps: {}".format(task, remaining_deps))
         return len(remaining_deps) == 0
 
-    def _update_entry(self, cur: sql.Cursor, entry: SlurmTask):
+    def _update_entry(
+        self, cur: sql.Cursor, entry: SlurmTask, logger: Logger = get_basic_logger()
+    ):
         """Updates all fields that have a value for the specific entry"""
-        for field, value in zip(
-            (self.col_job_id, self.col_status), (entry.job_id, entry.status)
-        ):
-            if value is not None:
-                cur.execute(
-                    "UPDATE state SET {} = ?, last_modified = strftime('%s','now') "
-                    "WHERE run_name = ? AND proc_type = ? and status < ?".format(field),
-                    (value, entry.run_name, entry.proc_type, entry.status),
+        if entry.status == const.Status.queued.value:
+            logger.debug(
+                "Got entry {} with status created. Setting status and job id in the db".format(
+                    entry
                 )
+            )
+            cur.execute(
+                "UPDATE state SET {} = ?, {} = ?, last_modified = strftime('%s','now') "
+                "WHERE run_name = ? AND proc_type = ? and status < ?".format(
+                    self.col_job_id, self.col_status
+                ),
+                (
+                    entry.job_id,
+                    entry.status,
+                    entry.run_name,
+                    entry.proc_type,
+                    entry.status,
+                ),
+            )
+        elif entry.job_id is not None:
+            cur.execute(
+                "UPDATE state SET status = ?, last_modified = strftime('%s','now') "
+                "WHERE run_name = ? AND proc_type = ? and status < ? and job_id = ?",
+                (
+                    entry.status,
+                    entry.run_name,
+                    entry.proc_type,
+                    entry.status,
+                    entry.job_id,
+                ),
+            )
+        else:
+            logger.warning(
+                "Recieved entry {}, status is more than created but the job_id is not set.".format(
+                    entry
+                )
+            )
+            cur.execute(
+                "UPDATE state SET status = ?, last_modified = strftime('%s','now') "
+                "WHERE run_name = ? AND proc_type = ? and status < ?",
+                (entry.status, entry.run_name, entry.proc_type, entry.status),
+            )
+        if cur.rowcount > 1:
+            logger.warning("Last database update caused {} entries to be updated".format(cur.rowcount))
         if entry.error is not None:
             cur.execute(
                 """INSERT INTO error (task_id, error)

--- a/scripts/plot_srf.sl
+++ b/scripts/plot_srf.sl
@@ -29,7 +29,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 start_time=`date +${runtime_fmt}`
 echo ___plotting SRF___
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf running $SLURM_JOB_ID
 res=`python $gmsim/visualization/visualization/gmt/plot_srf_square.py "$SRF_PATH" --out-dir "$OUTPUT_DIR"`
 exit_val=$?
 
@@ -47,7 +47,7 @@ if [[ $exit_val == 0 ]] && [[ $exit_val2 == 0 ]]; then
         mv "$STATIC_OUTPUT_MAP_PLOT_PATH" "$OUTPUT_DIR"
     fi
 
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf completed $SLURM_JOB_ID
 else
     errors=""
     if [[ $exit_val != 0 ]]; then
@@ -56,6 +56,6 @@ else
     if [[ $exit_val2 != 0 ]]; then
         errors+=" failed executing plot_srf_map.py "
     fi
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf failed --error "$errors"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_srf failed $SLURM_JOB_ID --error "$errors"
 fi
 

--- a/scripts/plot_ts.sl
+++ b/scripts/plot_ts.sl
@@ -27,7 +27,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 start_time=`date +${runtime_fmt}`
 echo ___plotting ts___
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts running $SLURM_JOB_ID
 res=`python $gmsim/visualization/visualization/gmt/plot_ts.py $XYTS_PATH --srf $SRF_PATH --output $OUTPUT_TS_PATH -n 36`
 exit_val=$?
 
@@ -37,8 +37,8 @@ echo $end_time
 if [[ $exit_val == 0 ]]; then
     #passed
 
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts completed $SLURM_JOB_ID
 
 else
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $SRF_NAME plot_ts failed $SLURM_JOB_ID --error "$res"
 fi

--- a/shared_workflow/shared_automated_workflow.py
+++ b/shared_workflow/shared_automated_workflow.py
@@ -30,6 +30,10 @@ def get_queued_tasks(user=None, machine=const.HPC.maui):
     process = Popen(shlex.split(cmd), stdout=PIPE, encoding="utf-8")
     (output, err) = process.communicate()
     process.wait()
+    if output.split("\n")[0] != "JOBID ST":
+        raise EnvironmentError(
+            "squeue did not return expected output. Ignoring for this iteration."
+        )
 
     output_list = list(filter(None, output.split("\n")[1:]))
     return output_list

--- a/templates/post_emod3d_merge_ts.sl.template
+++ b/templates/post_emod3d_merge_ts.sl.template
@@ -12,7 +12,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts running $SLURM_JOB_ID
 
 filelist={{sim_dir}}/LF/flist_{{srf_name}}
 #get tools dir from shared_defaults
@@ -31,11 +31,11 @@ rm $filelist
 res=`$gmsim/workflow/scripts/test_merge_ts.sh {{sim_dir}} {{srf_name}}`
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts completed $SLURM_JOB_ID
 
     #save meta data
     python $gmsim/workflow/metadata/log_metadata.py {{sim_dir}} merge_ts start_time=$start_time end_time=$end_time
 
 else
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} merge_ts failed $SLURM_JOB_ID --error "$res"
 fi

--- a/templates/run_bb_mpi.sl.template
+++ b/templates/run_bb_mpi.sl.template
@@ -4,7 +4,7 @@ if [[ ! -d {{mgmt_db_location}}/mgmt_db_queue ]]; then
     mkdir {{mgmt_db_location}}/mgmt_db_queue
 fi
 timestamp=`date +%Y%m%d_%H%M%S`
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB running $SLURM_JOB_ID
 
 runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
@@ -21,7 +21,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 res=`$gmsim/workflow/scripts/{{test_bb_script}} {{sim_dir}} `
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB completed $SLURM_JOB_ID
 
     if [[ ! -d {{sim_dir}}/ch_log ]]; then
         mkdir {{sim_dir}}/ch_log
@@ -34,7 +34,7 @@ if [[ $? == 0 ]]; then
 else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} BB failed $SLURM_JOB_ID --error "$res"
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_BB"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory

--- a/templates/run_emod3d.sl.template
+++ b/templates/run_emod3d.sl.template
@@ -14,7 +14,7 @@ runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
 echo $start_time
 
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D running $SLURM_JOB_ID
 {{submit_command}}
 
 end_time=`date +$runtime_fmt`
@@ -30,7 +30,7 @@ if [[ $? == 0 ]]; then
 fi
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D completed $SLURM_JOB_ID
     rm {{sim_dir}}/LF/Restart/*
 
     if [[ ! -d {{sim_dir}}/ch_log ]]; then
@@ -42,7 +42,7 @@ if [[ $? == 0 ]]; then
 else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} EMOD3D failed $SLURM_JOB_ID --error "$res"
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_LF"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory

--- a/templates/run_hf_mpi.sl.template
+++ b/templates/run_hf_mpi.sl.template
@@ -6,7 +6,7 @@ if [[ ! -d {{mgmt_db_location}}/mgmt_db_queue ]]; then
     mkdir {{mgmt_db_location}}/mgmt_db_queue
 fi
 timestamp=`date +%Y%m%d_%H%M%S`
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF running $SLURM_JOB_ID
 
 runtime_fmt="%Y-%m-%d_%H:%M:%S"
 start_time=`date +$runtime_fmt`
@@ -20,7 +20,7 @@ timestamp=`date +%Y%m%d_%H%M%S`
 res=`$gmsim/workflow/scripts/{{test_hf_script}} {{sim_dir}} `
 if [[ $? == 0 ]]; then
     #passed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF completed $SLURM_JOB_ID
 
     #save the parameters
     if [[ ! -d {{sim_dir}}/ch_log ]]; then
@@ -34,7 +34,7 @@ if [[ $? == 0 ]]; then
 else
     #reformat $res to remove '\n'
     res=`echo $res | tr -d '\n'`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF failed $SLURM_JOB_ID --error "$res"
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_HF"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory

--- a/templates/sim_im_calc.sl.template
+++ b/templates/sim_im_calc.sl.template
@@ -14,7 +14,7 @@ echo "script started running at: $script_start"
 
 # Update db to running
 timestamp=`date +%Y%m%d_%H%M%S`
-python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc running
+python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc running $SLURM_JOB_ID
 
 # Create the results directory if required
 if [[ ! -d {{sim_dir}}/IM_calc ]]; then
@@ -44,7 +44,7 @@ fi
 # Passed
 if [[ $res == 0 ]]; then
     timestamp=`date +%Y%m%d_%H%M%S`
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc completed
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc completed $SLURM_JOB_ID
 
     if [[ ! -d {{sim_dir}}/ch_log ]]; then
         mkdir {{sim_dir}}/ch_log
@@ -60,7 +60,7 @@ if [[ $res == 0 ]]; then
     fi
 else
     #failed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc failed --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} IM_calc failed $SLURM_JOB_ID --error "$res"
 fi
 
 


### PR DESCRIPTION
not received from squeue.
Jobs are not considered to have been cancelled/WCT killed if squeue does.
not respond correctly.
Changed add_to_mgmt_queue to take in the job id if possible to ensure the correct entry is updated.
Slurm scripts have been set to provide the job id.
If the job id is not provided the update is still applied, as each update should ony apply to one entry.
If multiple rows are modified by an update the user is alerted to this.

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

