### PR TITLE
Remove workflow config reference

### DIFF
--- a/scripts/set_runparams.py
+++ b/scripts/set_runparams.py
@@ -37,8 +37,8 @@ def create_run_params(
             os.path.dirname(os.path.realpath(__file__)), "workflow_config.json"
         )
     global_root = workflow_config["global_root"]
-    tools_dir = binary_version.get_lf_bin(params.emod3d.emod3d_version)
-    emod3d_version = workflow_config["emod3d_version"]
+    emod3d_version = params.emod3d.emod3d_version
+    tools_dir = binary_version.get_lf_bin(emod3d_version)
 
     e3d_yaml = os.path.join(
         workflow_config["templates_dir"],

--- a/scripts/set_runparams.py
+++ b/scripts/set_runparams.py
@@ -37,8 +37,8 @@ def create_run_params(
             os.path.dirname(os.path.realpath(__file__)), "workflow_config.json"
         )
     global_root = workflow_config["global_root"]
-    emod3d_version = params.emod3d.emod3d_version
-    tools_dir = binary_version.get_lf_bin(emod3d_version)
+    emod3d_version = params["emod3d"]["emod3d_version"]
+    emod3d_filepath = binary_version.get_lf_bin(emod3d_version)
 
     e3d_yaml = os.path.join(
         workflow_config["templates_dir"],
@@ -102,7 +102,7 @@ def create_run_params(
         )
 
         # other locations
-        e3d_dict["wcc_prog_dir"] = tools_dir
+        e3d_dict["wcc_prog_dir"] = emod3d_filepath
         e3d_dict["vel_mod_params_dir"] = params.vel_mod_dir
         e3d_dict["global_root"] = global_root
         e3d_dict["sim_dir"] = params.sim_dir


### PR DESCRIPTION
Keeping it there breaks LF runs when not using V3.0.4

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

