### PR TITLE
Default HF rayset is changed from 1 2 to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Slurm Ground Motion Workflow
 # Changelog
 (Based on https://wiki.canterbury.ac.nz/download/attachments/58458136/CodeVersioning_v18p2.pdf?version=1&modificationDate=1519269238437&api=v2 )
 
+## [19.6.23] -  2020-02-11 -- Changed HF Rayset default to 1 
+### Changed
+    - Changed HF Rayset default from 1 2 to 1, which is internally handled as [1]. 
+
 ## [19.6.22] -  2019-12-19 -- Added Advanced_IM into automated workflow
 ### Added
     - Added slurm templates related to Advanced_IM

--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -75,13 +75,7 @@ if is_master:
     # HF IN, line 1
     arg("--sdrop", help="stress drop average (bars)", type=float, default=50.0)
     # HF IN, line 4
-    arg(
-        "--rayset",
-        help="ray types 1:direct 2:moho",
-        nargs="+",
-        type=int,
-        default=[1],
-    )
+    arg("--rayset", help="ray types 1:direct 2:moho", nargs="+", type=int, default=[1])
     # HF IN, line 5
     arg(
         "--no-siteamp",

--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -80,7 +80,7 @@ if is_master:
         help="ray types 1:direct 2:moho",
         nargs="+",
         type=int,
-        default=[1, 2],
+        default=[1],
     )
     # HF IN, line 5
     arg(


### PR DESCRIPTION
#### Description
Default HF rayset is changed from 1 2 to 1, which is internally handled as [1], not [1,2] as it used to be. 
#### Dependencies
None
#### Checklist
- Have you updated the README : No need
- Have you updated the CHANGELOG : Yes 

