### PR TITLE
Cascading failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Slurm Ground Motion Workflow
     - removed partition specifier for mahuika slurm scripts (as per NeSI recommendations)
     - lowered core requirements on quick animation, less queue time
     - Does not create new tasks for faults that are re-installed
+    - When marking a task as failed it will mark that tasks depedencies as failed too. The output files are not touched
 ### Updated
     - E2E tests bugs fixed
 

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -117,7 +117,7 @@ class MgmtDB:
                                         const.Status.completed.value,
                                         entry.run_name,
                                     ),
-                                ).fetchone()
+                                ).fetchone()[0]
                                 print(job_id)
 
                                 if job_id is not None:

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -117,15 +117,15 @@ class MgmtDB:
                                         const.Status.completed.value,
                                         entry.run_name,
                                     ),
-                                ).fetchone()[0]
-                                print(job_id)
+                                ).fetchone()
 
                                 if job_id is not None:
+                                    print(job_id[0])
                                     dependant_entry = SlurmTask(
                                         entry.run_name,
                                         process.value,
                                         const.Status.failed.value,
-                                        job_id,
+                                        job_id[0],
                                         None,
                                     )
                                     self._update_entry(cur, dependant_entry, logger=logger)

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -105,10 +105,13 @@ class MgmtDB:
                 print("status", entry.status, const.Status.failed.value)
                 if entry.status == const.Status.failed.value:
                     tasks = self.find_dependant_task(cur, entry)
-                    for task in tasks:
+                    i = 0
+                    while i < len(tasks):
+                        task = tasks[i]
                         self._update_entry(cur, task, logger=logger)
                         logger.debug(f"Cascading failure for {entry.run_name} - {task.proc_type}")
                         tasks.extend(self.find_dependant_task(cur, task))
+                        i += 1
 
         except sql.Error as ex:
             self._conn.rollback()

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -106,6 +106,8 @@ class MgmtDB:
                 if entry.status == const.Status.failed.value:
                     for process in const.ProcessType:
                         for dependency in process.dependencies:
+                            if iter(dependency):
+                                dependency = dependency[0]
                             print("dependant process", entry.proc_type, dependency)
                             if entry.proc_type == dependency:
                                 job_id = cur.execute(

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -102,9 +102,11 @@ class MgmtDB:
                     logger.debug("New task added to the db")
 
                 # fails dependant task if parent task fails
+                print("status", entry.status, const.Status.failed.value)
                 if entry.status == const.Status.failed.value:
                     for process in const.ProcessType:
                         for dependency in process.dependencies:
+                            print("dependant process", entry.proc_type, dependency)
                             if entry.proc_type == dependency:
                                 job_id = cur.execute(
                                     "SELECT `job_id` FROM `state` WHERE proc_type = ? and status = ? and run_name = ?",
@@ -114,6 +116,7 @@ class MgmtDB:
                                         entry.run_name,
                                     ),
                                 ).fetchone()
+                                print(job_id)
 
                                 if job_id is not None:
                                     dependant_entry = SlurmTask(
@@ -124,6 +127,7 @@ class MgmtDB:
                                         None,
                                     )
                                     self._update_entry(cur, dependant_entry, logger=logger)
+                                    logger.debug(f"Cascading failure for {entry.run_name} - {entry.proc_type}")
 
         except sql.Error as ex:
             self._conn.rollback()

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -100,6 +100,31 @@ class MgmtDB:
                     )
                     self._insert_task(cur, realisation_name, process)
                     logger.debug("New task added to the db")
+
+                # fails dependant task if parent task fails
+                if entry.status == const.Status.failed.value:
+                    for process in const.ProcessType:
+                        for dependency in process.dependencies:
+                            if entry.proc_type == dependency:
+                                job_id = cur.execute(
+                                    "SELECT `job_id` FROM `state` WHERE proc_type = ? and status = ? and run_name = ?",
+                                    (
+                                        process.value,
+                                        const.Status.completed.value,
+                                        entry.run_name,
+                                    ),
+                                ).fetchone()
+
+                                if job_id is not None:
+                                    dependant_entry = SlurmTask(
+                                        entry.run_name,
+                                        process.value,
+                                        const.Status.failed.value,
+                                        job_id,
+                                        None,
+                                    )
+                                    self._update_entry(cur, dependant_entry, logger=logger)
+
         except sql.Error as ex:
             self._conn.rollback()
             logger.critical(

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -130,13 +130,13 @@ class MgmtDB:
 
         return True
 
+    @staticmethod
     def find_dependant_task(self, cur, entry):
         tasks = []
         for process in const.ProcessType:
             for dependency in process.dependencies:
                 if isinstance(dependency, tuple):
                     dependency = dependency[0]
-                print("dependant process", entry.proc_type, dependency)
                 if entry.proc_type == dependency:
                     job_id = cur.execute(
                         "SELECT `job_id` FROM `state` WHERE proc_type = ? and status = ? and run_name = ?",
@@ -148,7 +148,6 @@ class MgmtDB:
                     ).fetchone()
 
                     if job_id is not None:
-                        print(job_id[0])
                         dependant_entry = SlurmTask(
                             entry.run_name,
                             process.value,
@@ -158,7 +157,6 @@ class MgmtDB:
                         )
                         tasks.append(dependant_entry)
         return tasks
-
 
     def add_retries(self, n_max_retries: int):
         """Checks the database for failed tasks with less failures than the given n_max_retries.

--- a/scripts/management/MgmtDB.py
+++ b/scripts/management/MgmtDB.py
@@ -106,7 +106,7 @@ class MgmtDB:
                 if entry.status == const.Status.failed.value:
                     for process in const.ProcessType:
                         for dependency in process.dependencies:
-                            if iter(dependency):
+                            if isinstance(dependency, tuple):
                                 dependency = dependency[0]
                             print("dependant process", entry.proc_type, dependency)
                             if entry.proc_type == dependency:


### PR DESCRIPTION
So when you fail Emod (and may need to rerun it) it also marks any dependant completed tasks as failed.
So if emod, HF, BB was complete but we needed to rerun emod, marking emod as failed will fail BB so it won't try to run IM_Calc till BB is re-run. 

Files will need to be deleted separately. for corrupted runs. Better pre-state checks are a separate "feature".

