### PR TITLE
Add pertbfile to the emod3d defaults files for all versions.

### DIFF
--- a/shared_workflow/install_shared.py
+++ b/shared_workflow/install_shared.py
@@ -151,7 +151,7 @@ def install_simulation(
         if os.path.exists(vm_pert_file):
             # The perturbation file exists, use it
             root_params_dict["emod3d"]["model_style"] = 3
-            sim_params_dict["emod3d"]["pertb_file"] = vm_pert_file
+            sim_params_dict["emod3d"]["pertbfile"] = vm_pert_file
         else:
             # The perturbation file does not exist. Raise an exception
             message = f"The expected perturbation file {vm_pert_file} does not exist. Generate or move this file to the given location."

--- a/templates/gmsim/16.1/emod3d_defaults.yaml
+++ b/templates/gmsim/16.1/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.3.1/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.3.1/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.3.2/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.3.2/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.3.4/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.3.4/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.4.1/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.4.1/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.4.2/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.4.2/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/18.5.4.4/emod3d_defaults.yaml
+++ b/templates/gmsim/18.5.4.4/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/20.1.1.4/emod3d_defaults.yaml
+++ b/templates/gmsim/20.1.1.4/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/20.1.2.4/emod3d_defaults.yaml
+++ b/templates/gmsim/20.1.2.4/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/20.4.1.2/emod3d_defaults.yaml
+++ b/templates/gmsim/20.4.1.2/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/templates/gmsim/20.4.1.4/emod3d_defaults.yaml
+++ b/templates/gmsim/20.4.1.4/emod3d_defaults.yaml
@@ -36,6 +36,7 @@ maxmem: 1500
 model_style: 1
 nseis: 1
 order: 4
+pertbfile: none.pertb
 pmodfile: vp3dfile.p
 pointmt: 0
 qbndmax: 100.0

--- a/testing/test_scripts/test_set_runparams.py
+++ b/testing/test_scripts/test_set_runparams.py
@@ -49,6 +49,7 @@ maxmem=1500
 model_style=1
 nseis=1
 order=4
+pertbfile="none.pertb"
 pmodfile="vp3dfile.p"
 pointmt=0
 qbndmax=100.0


### PR DESCRIPTION
This will not affect runs without perturbations.
Correct the spelling of pertb_file to pertbfile.

The default value should never be used, but needs something there for the key to exist

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

