### PR TITLE
Update create_python_virtenv_mahuika.sh

### DIFF
--- a/install_workflow/create_python_virtenv_mahuika.sh
+++ b/install_workflow/create_python_virtenv_mahuika.sh
@@ -21,6 +21,7 @@ fi
 
 # update pip. python3 come with a v9.0 which is too old.
 pip install --upgrade pip
+pip install --upgrade setuptools
 
 # Install python packages
 # Using xargs means that each package is installed individually, which


### PR DESCRIPTION
Bug with outdated setup tools on mahuika environment generation. Installing setuptools manually helped so doing it on an enviroment level should work too. 

