### PR TITLE
Adv im fix

### DIFF
--- a/scripts/nesi_scripts/run_adv_im_obs_maui.sl
+++ b/scripts/nesi_scripts/run_adv_im_obs_maui.sl
@@ -46,7 +46,7 @@ do
     do
         # check for status
         # skip if completed
-        res=`python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model`; res_return_code=$?
+        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model; res_return_code=$?
 
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
@@ -54,7 +54,7 @@ do
         fi
         time python $IMPATH/calculate_ims.py $path_eventBB a -o $path_event_out -np 40 -i $event -r $event -t  o -e -a $adv_IM_model --OpenSees_path $opensees_bin
         # test for completion 
-        res=`python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model`; res_return_code=$?
+        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model; res_return_code=$?
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
             # completed
@@ -64,8 +64,8 @@ do
         else
             echo "completion test failed after running $adv_IM_model on $path_event_out"
             echo "something went wrong, stopping the job, check logs for $path_event_out for $adv_IM_model"
-            echo "$res"
-            exit 3
+            echo "error code $res_return_code"
+            exit $res_return_code
         fi
     done
 done

--- a/scripts/nesi_scripts/run_adv_im_obs_maui.sl
+++ b/scripts/nesi_scripts/run_adv_im_obs_maui.sl
@@ -33,6 +33,15 @@ do
     path_eventBB=$obs_dir/$event/*/*/accBB
     path_IM_calc=$obs_dir/IM_calc
     path_event_out=$path_IM_calc/$event
+
+    #get station list using get_bbseis from im_calculation.py
+    stations=($(python -c "from IM_calculation.IM.im_calculation import get_bbseis; _,stations = get_bbseis('$path_eventBB','ascii',None); print(" ".join(stations))"))
+    #get station_count
+    station_count=${#stations[@]}
+    if [[ $station_count -le 0 ]]; then
+        echo failed to get the station count in $path_eventBB
+        exit 2
+    fi
     # get module names used for simulation analysis
     root_params=`realpath $obs_dir/../Runs/root_params.yaml`
     if [[ $? == 0 ]] && [[ -f $root_params ]]; then
@@ -54,7 +63,7 @@ do
         fi
         time python $IMPATH/calculate_ims.py $path_eventBB a -o $path_event_out -np 40 -i $event -r $event -t  o -e -a $adv_IM_model --OpenSees_path $opensees_bin
         # test for completion 
-        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model; res_return_code=$?
+        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
             # completed

--- a/scripts/nesi_scripts/run_adv_im_obs_maui.sl
+++ b/scripts/nesi_scripts/run_adv_im_obs_maui.sl
@@ -55,7 +55,7 @@ do
     do
         # check for status
         # skip if completed
-        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model; res_return_code=$?
+        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
 
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then

--- a/scripts/nesi_scripts/run_adv_im_obs_maui.sl
+++ b/scripts/nesi_scripts/run_adv_im_obs_maui.sl
@@ -33,12 +33,6 @@ do
     path_eventBB=$obs_dir/$event/*/*/accBB
     path_IM_calc=$obs_dir/IM_calc
     path_event_out=$path_IM_calc/$event
-    # get station count
-    station_count=`ls $path_eventBB | cut -d. -f1 | sort -u | wc -l`
-    if [[ $station_count -le 0 ]]; then
-        echo failed to get the station count in $path_eventBB
-        exit 2
-    fi
     # get module names used for simulation analysis
     root_params=`realpath $obs_dir/../Runs/root_params.yaml`
     if [[ $? == 0 ]] && [[ -f $root_params ]]; then
@@ -52,7 +46,7 @@ do
     do
         # check for status
         # skip if completed
-        res=`python $gmsim/workflow/scripts/verify_adv_IM.py $path_event_out $adv_IM_model`; res_return_code=$?
+        res=`python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model`; res_return_code=$?
 
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
@@ -60,7 +54,7 @@ do
         fi
         time python $IMPATH/calculate_ims.py $path_eventBB a -o $path_event_out -np 40 -i $event -r $event -t  o -e -a $adv_IM_model --OpenSees_path $opensees_bin
         # test for completion 
-        res=`python $gmsim/workflow/scripts/verify_adv_IM.py $path_event_out $adv_IM_model`; res_return_code=$?
+        res=`python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model`; res_return_code=$?
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
             # completed

--- a/scripts/nesi_scripts/run_adv_im_obs_maui.sl
+++ b/scripts/nesi_scripts/run_adv_im_obs_maui.sl
@@ -13,8 +13,8 @@
 #SBATCH --hint=nomultithread
 #SBATCH --exclusive
 
-export IMPATH=$gmsim/IM_calculation/IM_calculation/scripts
-export PYTHONPATH=$gmsim/qcore:/$PYTHONPATH:$IMPATH
+export IMPATH=$gmsim/IM_calculation/IM_calculation
+export PYTHONPATH=$gmsim/qcore:/$PYTHONPATH:$IMPATH/scripts
 
 if [[ $# -lt 2 ]];
 then
@@ -35,7 +35,7 @@ do
     path_event_out=$path_IM_calc/$event
 
     #get station list using get_bbseis from im_calculation.py
-    stations=($(python -c "from IM_calculation.IM.im_calculation import get_bbseis; _,stations = get_bbseis('$path_eventBB','ascii',None); print(" ".join(stations))"))
+    stations=($(python -c "from IM_calculation.IM.im_calculation import get_bbseis; _,stations = get_bbseis('$path_eventBB','ascii',None); print(' '.join(stations))"))
     #get station_count
     station_count=${#stations[@]}
     if [[ $station_count -le 0 ]]; then
@@ -55,15 +55,15 @@ do
     do
         # check for status
         # skip if completed
-        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
+        python $IMPATH/Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
 
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
             continue
         fi
-        time python $IMPATH/calculate_ims.py $path_eventBB a -o $path_event_out -np 40 -i $event -r $event -t  o -e -a $adv_IM_model --OpenSees_path $opensees_bin
+        time python $IMPATH/scripts/calculate_ims.py $path_eventBB a -o $path_event_out -np 40 -i $event -r $event -t  o -e -a $adv_IM_model --OpenSees_path $opensees_bin
         # test for completion 
-        python $IMPATH/../Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
+        python $IMPATH/Advanced_IM/check_adv_IM_status.py $path_event_out $adv_IM_model --stations ${stations[@]}; res_return_code=$?
         # return code from verify_adv_IM is used to determine status.
         if [[ $res_return_code == 0 ]];then
             # completed

--- a/templates/adv_im_calc.sl.template
+++ b/templates/adv_im_calc.sl.template
@@ -32,8 +32,9 @@ end_time=`date +$runtime_fmt`
 
 # verify the result of the analysis
 fd_name=$(getFromYaml "{{sim_dir}}/sim_params.yaml" FD_STATLIST)
-res=`python $IMPATH/../Advanced_IM/check_adv_IM_status.py {{sim_IM_calc_dir}} {{models}} --station_file $fd_name`
-success=$?
+echo "=========="
+python $IMPATH/../Advanced_IM/check_adv_IM_status.py {{sim_IM_calc_dir}} {{models}} --stations {{station_file}}; success=$?
+echo "=========="
 
 # Update mgmt_db
 # Passed
@@ -55,7 +56,7 @@ if [[ $success == 0 ]]; then
     gzip {{sim_IM_calc_dir}}/adv_im_out.tar
 else
     #failed
-    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} $step_name failed $SLURM_JOB_ID --error "$res"
+    python $gmsim/workflow/scripts/cybershake/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} $step_name failed $SLURM_JOB_ID --error "error: $success"
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_$step_name"
     echo "Completion test failed, moving all files to $backup_directory"
     mkdir -p $backup_directory


### PR DESCRIPTION
#### Description
1.updated the station matching logic so that is match both ways, this address the bug that when observed data have stations that was not included in simulation (thus failing the check_status).

2. The result of check_status is also set to flush to job_id.out so its easier to check the result, instead of logging in mgmt_db, which require more steps to check the output. the 
DB now logs the error code, instead of full message.

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

