### PR TITLE
quick bandaid fix for params==None

### DIFF
--- a/scripts/hf_sim.py
+++ b/scripts/hf_sim.py
@@ -542,7 +542,7 @@ if __name__ == "__main__":
 
     v1d_path = args.hf_vel_mod_1d
     for s in range(work.size):
-        if args.site_v1d_dir is not None:
+        if args.site_specific:
             v1d_path = os.path.join(
                 args.site_v1d_dir, f"{work[s]['name'].decode('ascii')}.1d"
             )

--- a/scripts/submit_hf.py
+++ b/scripts/submit_hf.py
@@ -44,7 +44,7 @@ def gen_command_template(params, machine, seed=const.HF_DEFAULT_SEED):
     }
     add_args = {}
     for k, v in params.hf.items():
-        if v is False:
+        if v is False or v is None:
             continue
         add_args[k] = " ".join(map(str, v)) if (type(v) is list) else v
 


### PR DESCRIPTION
#### Description
a quick bandaid fix for params == None.
it was getting parsed to "None"(string)
and causing crashes
#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

