### PR TITLE
Install qcore like the old docker did

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         mkdir -p /tmp/${env.JOB_NAME}/sample0
         cd /tmp/${env.JOB_NAME}
         git clone https://github.com/ucgmsim/qcore.git
-	PYTHONPATH=/tmp/${env.JOB_NAME}/qcore:$PYTHONPATH
+	PYTHONPATH=/tmp/${env.JOB_NAME}/qcore:${PYTHONPATH}
 
         ln -s $HOME/data/testing/slurm_gm_workflow/SGMW /tmp/${env.JOB_NAME}/build
         cd /tmp/${env.JOB_NAME}/sample0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@ pipeline {
         mkdir -p /tmp/${env.JOB_NAME}/sample0
         cd /tmp/${env.JOB_NAME}
         git clone https://github.com/ucgmsim/qcore.git
-	cd /home/jenkins/qcore
-	python setup.py install --user --no-data
+	export PYTHONPATH=/tmp/${env.JOB_NAME}/qcore:$PYTHONPATH
 
         ln -s $HOME/data/testing/slurm_gm_workflow/SGMW /tmp/${env.JOB_NAME}/build
         cd /tmp/${env.JOB_NAME}/sample0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         mkdir -p /tmp/${env.JOB_NAME}/sample0
         cd /tmp/${env.JOB_NAME}
         git clone https://github.com/ucgmsim/qcore.git
-	export PYTHONPATH=/tmp/${env.JOB_NAME}/qcore:$PYTHONPATH
+	PYTHONPATH=/tmp/${env.JOB_NAME}/qcore:$PYTHONPATH
 
         ln -s $HOME/data/testing/slurm_gm_workflow/SGMW /tmp/${env.JOB_NAME}/build
         cd /tmp/${env.JOB_NAME}/sample0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ pipeline {
         mkdir -p /tmp/${env.JOB_NAME}/sample0
         cd /tmp/${env.JOB_NAME}
         git clone https://github.com/ucgmsim/qcore.git
+	cd /home/jenkins/qcore
+	python setup.py install --user --no-data
 
         ln -s $HOME/data/testing/slurm_gm_workflow/SGMW /tmp/${env.JOB_NAME}/build
         cd /tmp/${env.JOB_NAME}/sample0


### PR DESCRIPTION
If we don't need qcore to be installed each time, then we can remove the clone line. 
It should be based on latest qcore though.

This is to counter a change made in #388 line 36 of the old jenkins file

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

