### PR TITLE
spelling and printing summary

### DIFF
--- a/scripts/cybershake/cybershake_progress.py
+++ b/scripts/cybershake/cybershake_progress.py
@@ -267,12 +267,12 @@ def print_progress(progress_df: pd.DataFrame):
         )
         summary += line + "\n"
 
+    print(summary)
     return summary
 
 
 def send2slack(msg, users, url):
     summary = " ".join(users) + "\n" + msg  # .encode('utf-8')
-    print(summary)
     data = json.dumps({"text": summary})
     urlopen(url, data=data.encode("utf-8"))
 

--- a/scripts/schedulers/slurm.py
+++ b/scripts/schedulers/slurm.py
@@ -28,7 +28,7 @@ class Slurm(AbstractScheduler):
             account = self.account
         accounts = ",".join(self.platform_accounts)
         if user:
-            # user is True, so we use the same use as we use for submission
+            # user is True, so we use the same user as we use for submission
             cmd = f"squeue -A {accounts} -o '%A %t' -M {target_machine.name} -u {self.user_name}"
         else:
             cmd = f"squeue -A {accounts} -o '%A %t' -M {target_machine.name}"


### PR DESCRIPTION
Moving the print for the summary for CS progress to always happen instead of only if you are posting to slack. 