### PR TITLE
Add old style environment loading

### DIFF
--- a/workflow/environments/extra_bashrc_functions.sh
+++ b/workflow/environments/extra_bashrc_functions.sh
@@ -16,7 +16,12 @@ activate_env () {
             echo "You might be lost, or more likely this is not working as planned!"
         fi
     fi
+    {
     source ${env_path}/workflow/workflow/environments/helper_functions/activate_env.sh ${env_path} ${hpc}
+    } || {
+    echo "Loading new style environment failed. Attemping to load old style."
+    source ${env_path}/workflow/install_workflow/helper_functions/activate_env.sh ${env_path} ${hpc}
+    }
 }
 
 deactivate_env () {


### PR DESCRIPTION
Aimed at environments stuck in the past (e.g. leer2)
Ran into the inverse problem on NeSI and have added similar to the shared bashrc

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

