### PR TITLE
bug with quotes in the argument

### DIFF
--- a/workflow/automation/org/nesi/calc_rrups_single.sl
+++ b/workflow/automation/org/nesi/calc_rrups_single.sl
@@ -44,7 +44,7 @@ then
     # Create the output folder if needed
     echo ___calculating rrups___
 
-    cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup running $SLURM_JOB_ID --start_time '$start_time' --nodes $SLURM_NNODES --cores $SLURM_CPUS_PER_TASK --wct 00:10:00"
+    cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup running $SLURM_JOB_ID --start_time $start_time --nodes $SLURM_NNODES --cores $SLURM_CPUS_PER_TASK --wct 00:10:00"
     #echo $cmd
     $cmd
 
@@ -62,7 +62,7 @@ if [[ -f ${OUT_FILE} ]]
 then
     if [[ $(wc -l < ${OUT_FILE}) == $(( $(wc -l < ${FD}) + 1)) ]]
     then
-        cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup completed $SLURM_JOB_ID --end_time '$end_time'"
+        cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup completed $SLURM_JOB_ID --end_time $end_time"
         #echo $cmd
         $cmd
     else
@@ -74,7 +74,7 @@ fi
 
 if [[ -n ${res} ]]
 then
-    cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup failed $SLURM_JOB_ID --error '$res' --end_time '$end_time'"
+    cmd="python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME rrup failed $SLURM_JOB_ID --error '$res' --end_time $end_time"
     #echo $cmd
     $cmd
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/nesi/project/nesi00213/Environments/jason/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py", line 107, in <module>
    start_time=datestr_to_timestamp(args.start_time),
  File "/nesi/project/nesi00213/Environments/jason/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py", line 16, in datestr_to_timestamp
    if time is not None
  File "/opt/nesi/mahuika/Python/3.6.3-gimkl-2017a/lib/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/opt/nesi/mahuika/Python/3.6.3-gimkl-2017a/lib/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data "'2022-07-01_03:52:17'" does not match format '%Y-%m-%d_%H:%M:%S'
```

Appears to work after this fix now.

@joelridden Are you able to have a quick look at the other slurms to double check that none of them won't have this error.

plot_srf, vm_gen, install_fault, hf, EMOD3D appears to work for me.