### PR TITLE
removed line from header

### DIFF
--- a/workflow/automation/templates/nesi_header.cfg
+++ b/workflow/automation/templates/nesi_header.cfg
@@ -7,6 +7,6 @@
 #SBATCH --job-name={{job_name}}
 #SBATCH --ntasks={{n_tasks}}
 #SBATCH --time={{wallclock_limit}}
-wct={{wallclock_limit}}
 {{additional_lines}}
 ## END HEADER
+wct={{wallclock_limit}}

--- a/workflow/automation/templates/nesi_header.cfg
+++ b/workflow/automation/templates/nesi_header.cfg
@@ -8,5 +8,6 @@
 #SBATCH --ntasks={{n_tasks}}
 #SBATCH --time={{wallclock_limit}}
 {{additional_lines}}
+
 ## END HEADER
 wct={{wallclock_limit}}

--- a/workflow/automation/tests/test_shared_workflow/test_shared_template.py
+++ b/workflow/automation/tests/test_shared_workflow/test_shared_template.py
@@ -76,7 +76,7 @@ def test_resolve_header(set_up):
     func_name = "resolve_header"
     func = shared_template.resolve_header
     params = inspect.getfullargspec(func).args
-    bench_variable_lines = [11, 12]
+    bench_variable_lines = [9, 11, 12]
     output_variable_lines = [9, 11, 12]
     for root_path, realisation in set_up:
         input_params = get_input_params(root_path, func_name, params)


### PR DESCRIPTION
```
     JOBID PARTIT                         NAME     USER           START_TIME    STATE       TIME TIME_LIMI NODES  CPUS
   2664012 nesi_r     emod3d.2013p613797_REL01   jmotha         Jul 05 00:54  RUNNING    1:47:23   4:10:00    10   800
   2664102 nesi_r     emod3d.2013p543824_REL01   jmotha                  N/A  PENDING       0:00   4:30:00    13   520
```

The change below meant hyperthreading was turned on (spot the difference)

Turns out Slurm requires all header rows before any bash lines.
(sorry for the additional PR - I didn't notice this earlier)