### PR TITLE
changed the dpart_perturbation to only be added for version of .4

### DIFF
--- a/workflow/calculation/hf_sim.py
+++ b/workflow/calculation/hf_sim.py
@@ -468,10 +468,11 @@ if __name__ == "__main__":
             )
         # add seekbyte for qcore adjusted version
         if bin_mod:
+            # Only add the dpath_perturbation for versions that has the tail version of .4
             if (
                 utils.compare_versions(args.version, "5.4.5.4") >= 0
                 and len(args.version.split(".")) >= 4
-                and utils.compare_versions(args.version.split(".")[3], "4") >= 0
+                and utils.compare_versions(args.version.split(".")[3], "4") == 0
             ):
                 hf_sim_args.append(str(args.dpath_pert))
             hf_sim_args.append(str(head_total + idx_0 * (nt * N_COMP * FLOAT_SIZE)))


### PR DESCRIPTION
In the newer compiled versions of hf, the dpart perturbation parameter isn't being used. Robin's currently used version of 6.0.3.9 doesn't have this feature and therefore is broken with the master version of hf_sim.py

