### PR TITLE
WCT retries fix

### DIFF
--- a/workflow/automation/execution_scripts/auto_submit.py
+++ b/workflow/automation/execution_scripts/auto_submit.py
@@ -173,6 +173,7 @@ def submit_task(
         submit_im_calc_slurm(
             sim_dir=sim_dir,
             simple_out=True,
+            retries=retries,
             target_machine=get_target_machine(const.ProcessType.IM_calculation).name,
             logger=task_logger,
         )

--- a/workflow/automation/execution_scripts/queue_monitor.py
+++ b/workflow/automation/execution_scripts/queue_monitor.py
@@ -181,7 +181,7 @@ def update_tasks(
                         const.Status.killed_WCT.value
                         if killed_wct
                         else const.Status.failed.value,
-                        None,
+                        db_running_task.job_id,
                         f"Disappeared from {Scheduler.get_scheduler().QUEUE_NAME}.",
                     )
                 )

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -137,7 +137,7 @@ class MgmtDB:
                         entry.queued_time,
                     )
 
-                if entry.status == const.Status.running.value:
+                elif entry.status == const.Status.running.value:
                     # Add general metadata to the job log when the task has started running
                     logger.debug("Logging running task to the db")
                     self.update_job_log(
@@ -150,7 +150,7 @@ class MgmtDB:
                         entry.wct,
                     )
 
-                if entry.status == const.Status.created.value:
+                elif entry.status == const.Status.created.value:
                     # Something has attempted to set a task to created
                     # Make a new task with created status and move to the next task
                     logger.debug("Adding new task to the db")
@@ -183,18 +183,6 @@ class MgmtDB:
                     )
 
                 if (
-                    entry.status == const.Status.failed.value
-                    and self.get_retries(process, realisation_name, get_WCT=False) + 1
-                    < retry_max
-                ):
-                    # The task was failed. If there have been few enough other attempts at the task make another one
-                    logger.debug(
-                        "Task failed but is able to be retried. Adding new task to the db"
-                    )
-                    self._insert_task(cur, realisation_name, process)
-                    logger.debug("New task added to the db")
-
-                if (
                     entry.status == const.Status.killed_WCT.value
                     and self.get_retries(process, realisation_name, get_WCT=True) + 1
                     < retry_max
@@ -202,6 +190,17 @@ class MgmtDB:
                     # The task was killed_WCT. If there have been few enough other attempts at the task make another one
                     logger.debug(
                         "Task hit WCT but is able to be retried. Adding new task to the db"
+                    )
+                    self._insert_task(cur, realisation_name, process)
+                    logger.debug("New task added to the db")
+                elif (
+                    entry.status == const.Status.failed.value
+                    and self.get_retries(process, realisation_name, get_WCT=False) + 1
+                    < retry_max
+                ):
+                    # The task was failed. If there have been few enough other attempts at the task make another one
+                    logger.debug(
+                        "Task failed but is able to be retried. Adding new task to the db"
                     )
                     self._insert_task(cur, realisation_name, process)
                     logger.debug("New task added to the db")

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -184,7 +184,7 @@ class MgmtDB:
 
                 if (
                     entry.status == const.Status.failed.value
-                    and self.get_retries(process, realisation_name, get_WCT=False)
+                    and self.get_retries(process, realisation_name, get_WCT=False) + 1
                     < retry_max
                 ):
                     # The task was failed. If there have been few enough other attempts at the task make another one
@@ -196,7 +196,7 @@ class MgmtDB:
 
                 if (
                     entry.status == const.Status.killed_WCT.value
-                    and self.get_retries(process, realisation_name, get_WCT=True)
+                    and self.get_retries(process, realisation_name, get_WCT=True) + 1
                     < retry_max
                 ):
                     # The task was killed_WCT. If there have been few enough other attempts at the task make another one

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -92,7 +92,7 @@ class MgmtDB:
     def db_file(self):
         return self._db_file
 
-    def get_retries(self, process, realisation_name, get_WCT = False):
+    def get_retries(self, process, realisation_name, get_WCT=False):
         get_WCT_symbol = "=" if get_WCT else "!="
         with connect_db_ctx(self._db_file) as cur:
             return cur.execute(

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -92,11 +92,12 @@ class MgmtDB:
     def db_file(self):
         return self._db_file
 
-    def get_retries(self, process, realisation_name):
+    def get_retries(self, process, realisation_name, get_WCT = False):
+        get_WCT_symbol = "=" if get_WCT else "!="
         with connect_db_ctx(self._db_file) as cur:
             return cur.execute(
                 "SELECT COUNT(*) from state "
-                "WHERE run_name = ? AND proc_type = ? and status != ?",
+                f"WHERE run_name = ? AND proc_type = ? and status {get_WCT_symbol} ?",
                 (realisation_name, process, const.Status.killed_WCT.value),
             ).fetchone()[0]
 
@@ -424,7 +425,7 @@ class MgmtDB:
                 ).fetchall()
                 runnable_tasks.extend(
                     [
-                        (*task, self.get_retries(*task))
+                        (*task, self.get_retries(*task, get_WCT=True))
                         for task in db_tasks
                         if self._check_dependancy_met(task, logger)
                         and "{}__{}".format(*task) not in tasks_waiting_for_updates

--- a/workflow/automation/submit/submit_sim_imcalc.py
+++ b/workflow/automation/submit/submit_sim_imcalc.py
@@ -31,6 +31,7 @@ def submit_im_calc_slurm(
     write_dir: str = None,
     simple_out: bool = True,
     adv_ims: bool = False,
+    retries: int = 0,
     target_machine: str = get_target_machine(const.ProcessType.IM_calculation).name,
     logger: Logger = get_basic_logger(),
 ):
@@ -193,6 +194,7 @@ def submit_im_calc_slurm(
     # Header options requiring upstream settings
     # special treatment for im_calc, as the scaling feature in estimation is not suitable
     # cap the wct, otherwise cannot submit
+    est_run_time = est_run_time * (int(retries) + 1)
     est_run_time = min(est_run_time * CH_SAFETY_FACTOR, qconfig["MAX_JOB_WCT"])
     # set ch_safety_factor=1 as we scale it already.
     header_options["wallclock_limit"] = get_wct(est_run_time, ch_safety_factor=1)


### PR DESCRIPTION
Manages issue where a job can infinity be in WCT.
Now 2 different checks for max retries, check both failed and killed_WCT individually if they are less than the max retries before submitting a new job.
Added Increase WCT for IM_calc.