### PR TITLE
Submitting IM_Calc fix

### DIFF
--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -493,6 +493,7 @@ def est_IM_chours_single(
         core_hours, wct, n_cores = scale_core_hours(
             core_hours, data, node_time_th_factor
         )
+        core_hours, n_cores = float(core_hours), int(n_cores)
 
     return core_hours, core_hours / n_cores, n_cores
 

--- a/workflow/automation/tests/test_metadata/test_agg_json_data.py
+++ b/workflow/automation/tests/test_metadata/test_agg_json_data.py
@@ -155,10 +155,10 @@ class TestAggJsonData:
                 assert df[col].dtype == np.dtype(bool)
             # Check run time and core hours column
             elif col[1] == const.MetadataField.run_time.value:
-                assert df[col].dtype == np.dtype(np.float)
+                assert df[col].dtype == np.dtype(np.float64)
                 assert df[
                     col[0], const.MetadataField.core_hours.value
-                ].dtype == np.dtype(np.float)
+                ].dtype == np.dtype(np.float64)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
est_IM_chours_single produced an error when scaling core hours as the scale_core_hours function returned np.float64 for core_hours and an array for cores.
This caused issues later down when trying to format to wct 
"{0:02.0f}:{1:02.0f}:00".format(*divmod(run_time * 60, 60))