### PR TITLE
Fix HF seed bug

### DIFF
--- a/workflow/automation/submit/submit_hf.py
+++ b/workflow/automation/submit/submit_hf.py
@@ -42,13 +42,11 @@ def gen_command_template(params, machine, seed=const.HF_DEFAULT_SEED):
             params["hf"]["version"], get_machine_config(machine)["tools_dir"]
         ),
     }
-    add_args = {}
+    add_args = {const.RootParams.seed.value: seed}
     for k, v in params["hf"].items():
         if v is False or v is None:
             continue
         add_args[k] = " ".join(map(str, v)) if (type(v) is list) else v
-
-    add_args.update({const.RootParams.seed.value: seed})
 
     return command_template_parameters, add_args
 


### PR DESCRIPTION
Setting the HF seed at the end resulted in all jobs getting the same seed value. This seed value is taken from root_params.yaml, or set to 0 if not available. This means that all realisations got the same seed, or all had a random seed, even if one was set in sim_params.yaml. This fix means that if a seed is available it will be used as it will be caught by the for loop, while realisations without an explicit seed will still use the shared/0 value as it did previously.

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

