### PR TITLE
Change HF checkpointing

### DIFF
--- a/workflow/calculation/hf_sim.py
+++ b/workflow/calculation/hf_sim.py
@@ -359,12 +359,12 @@ if __name__ == "__main__":
                         hff,
                         count=stations.size,
                         dtype={
-                            "names": ["vs"],
+                            "names": ["e_dist"],
                             "formats": ["f4"],
-                            "offsets": [20],
+                            "offsets": [16],
                             "itemsize": HEAD_STAT,
                         },
-                    )["vs"]
+                    )["e_dist"]
                     > 0
                 )
         except IOError:


### PR DESCRIPTION
Previously vs values were used. 
These values are written after the binary runs, but before the output is checked. 
Now using e_dist (epicentre distance) values. 
e_dist values are read from the HF binary stderr and then written to the file after the vs value is written. 
Checking against e_dist values means that in future we can resume sites that had an issue with reading the e_dist, such as the HF binary crashing.
Currently these sites would be considered complete as the vs value has already been written before the issue is discovered.
The alternative change is to write vs values after e_dist values, but this was the smaller edit to make.

#### Description

#### Dependencies

#### Checklist
- Have you updated the README (yes/no)?
- Have you updated the CHANGELOG (yes/no)? 

