### PR TITLE
Estimation fixes due to core hour scaling

### DIFF
--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -132,12 +132,12 @@ def confine_wct_node_parameters(
             f"Job parameters total ch ({core_count * run_time}) below minimum core-hour bounds ({max_core_hours}). "
             f"Reducing wall clock time to fit."
         )
-        run_time = min(ch / core_count, max_wct)
         if not preserve_core_count:
             core_count = min(
                 scale_cc(ch, max_wct),
                 max_core_count,
             )
+        run_time = min(ch / core_count, max_wct)
 
     if run_time < min_wct:
         run_time = min_wct

--- a/workflow/automation/tests/test_estimation/test_estimation.py
+++ b/workflow/automation/tests/test_estimation/test_estimation.py
@@ -96,6 +96,7 @@ MAX_JOB_WCT = qconfig[config.ConfigKeys.MAX_JOB_WCT.name]
 MAX_NODES_PER_JOB = qconfig[config.ConfigKeys.MAX_NODES_PER_JOB.name]
 PHYSICAL_NCORES_PER_NODE = qconfig[config.ConfigKeys.cores_per_node.name]
 MAX_CH_PER_JOB = qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
+CH_SAFTEY_FACTOR = 1.5
 
 
 @pytest.mark.parametrize(
@@ -104,12 +105,12 @@ MAX_CH_PER_JOB = qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
         (
             (PHYSICAL_NCORES_PER_NODE * 2, MAX_JOB_WCT / 2),
             PHYSICAL_NCORES_PER_NODE * 2,
-            MAX_JOB_WCT / 2,
+            MAX_JOB_WCT / (2 / CH_SAFTEY_FACTOR),
         ),
         (
             (PHYSICAL_NCORES_PER_NODE, MAX_JOB_WCT + 1),
             PHYSICAL_NCORES_PER_NODE * 2,
-            (MAX_JOB_WCT + 1) / 2,
+            (MAX_JOB_WCT + 1) / (2 / CH_SAFTEY_FACTOR),
         ),
         (
             (PHYSICAL_NCORES_PER_NODE * MAX_NODES_PER_JOB * 2, MAX_JOB_WCT / 2),
@@ -140,7 +141,7 @@ def test_confine_wct_node_parameters(in_params, out_count, out_time):
         cores_per_node=PHYSICAL_NCORES_PER_NODE,
         hyperthreaded=False,
         can_checkpoint=True,
-        ch_safety_factor=1.0,
+        ch_safety_factor=CH_SAFTEY_FACTOR,
     )
 
     assert np.isclose(test_count, out_count)


### PR DESCRIPTION
Fixing few issues that popped up when core hours are being scaled.
Includes fix for run time adjustment after core count changes when in the green zone

