### PR TITLE
Estimation for LF memory

### DIFF
--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -18,8 +18,10 @@ from qcore.qclogging import get_basic_logger
 MAX_JOB_WCT = config.qconfig[config.ConfigKeys.MAX_JOB_WCT.name]
 MAX_NODES_PER_JOB = config.qconfig[config.ConfigKeys.MAX_NODES_PER_JOB.name]
 PHYSICAL_NCORES_PER_NODE = config.qconfig[config.ConfigKeys.cores_per_node.name]
+MEMORY_PER_NODE = config.qconfig[config.ConfigKeys.memory_per_node.name]  # In Gb
 MAX_CH_PER_JOB = config.qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
 
+MEMORY_PER_GRID_POINT = 150 / 1e9  # In Gb
 CH_SAFETY_FACTOR = 1.5
 ERROR_MSG_SHAPE_MISMATCH = "Invalid input data, has to be {required_column_count} columns. One for each feature."
 
@@ -162,12 +164,10 @@ def est_min_ncores_LF(data: np.ndarray):
     :param data: The data to use to estimate the number of cores required
     :return: The estimated number of cores required
     """
-    mem_cap_per_core = 1.5  # In Gb
-    mem_per_gp = 20 * 4 / 1e9  # In Gb
     n_grid_points = data[:, 0] * data[:, 1] * data[:, 2]
 
     # Estimate the number of cores required for memory
-    n_cores = np.ceil(mem_per_gp * n_grid_points / mem_cap_per_core)
+    n_cores = np.ceil(MEMORY_PER_GRID_POINT * n_grid_points / MEMORY_PER_NODE)
 
     # Ensure we scale up to fill a full node
     n_cores = np.ceil(n_cores / PHYSICAL_NCORES_PER_NODE) * PHYSICAL_NCORES_PER_NODE

--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -18,7 +18,7 @@ from qcore.qclogging import get_basic_logger
 MAX_JOB_WCT = config.qconfig[config.ConfigKeys.MAX_JOB_WCT.name]
 MAX_NODES_PER_JOB = config.qconfig[config.ConfigKeys.MAX_NODES_PER_JOB.name]
 PHYSICAL_NCORES_PER_NODE = config.qconfig[config.ConfigKeys.cores_per_node.name]
-MEMORY_PER_NODE = config.qconfig[config.ConfigKeys.memory_per_node.name]  # In Gb
+MEMORY_PER_CORE = config.qconfig[config.ConfigKeys.memory_per_core.name]  # In Gb
 MAX_CH_PER_JOB = config.qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
 
 MEMORY_PER_GRID_POINT = 150 / 1e9  # In Gb
@@ -167,7 +167,7 @@ def est_min_ncores_LF(data: np.ndarray):
     n_grid_points = data[:, 0] * data[:, 1] * data[:, 2]
 
     # Estimate the number of cores required for memory
-    n_cores = np.ceil(MEMORY_PER_GRID_POINT * n_grid_points / MEMORY_PER_NODE)
+    n_cores = np.ceil(MEMORY_PER_GRID_POINT * n_grid_points / MEMORY_PER_CORE)
 
     # Ensure we scale up to fill a full node
     n_cores = np.ceil(n_cores / PHYSICAL_NCORES_PER_NODE) * PHYSICAL_NCORES_PER_NODE

--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -29,6 +29,7 @@ def confine_wct_node_parameters(
     run_time: float,
     max_wct: float = float(MAX_JOB_WCT),
     min_wct: float = (const.CHECKPOINT_DURATION * 3) / 60.0,
+    min_core_count: int = PHYSICAL_NCORES_PER_NODE,
     max_core_count: int = MAX_NODES_PER_JOB * PHYSICAL_NCORES_PER_NODE,
     max_core_hours: int = MAX_CH_PER_JOB,
     cores_per_node: int = PHYSICAL_NCORES_PER_NODE,
@@ -54,6 +55,8 @@ def confine_wct_node_parameters(
     :param max_wct: The maximum wall clock time available for the current queue
     :param min_wct: The minimum wall clock time for a given job. Based on desired frequency of checkpointing, even if
     the job does not support checkpointing.
+    :param min_core_count: The minimum core count possible for the current queue or job.
+    (Can be set higher for when you need certain memory requirements)
     :param max_core_count: The maximum core count possible for the current queue or job. Set to
     PHYSICAL_NCORES_PER_NODE to only use one node
     :param max_core_hours: The maximum core hours possible for a single job in the current queue
@@ -117,7 +120,7 @@ def confine_wct_node_parameters(
         )
         if not preserve_core_count:
             core_count = min(
-                scale_cc(ch, max_wct),
+                max(min_core_count, scale_cc(ch, max_wct)),
                 max_core_count,
             )
         run_time = min(ch / core_count, max_wct)
@@ -134,7 +137,7 @@ def confine_wct_node_parameters(
         )
         if not preserve_core_count:
             core_count = min(
-                scale_cc(ch, max_wct),
+                max(min_core_count, scale_cc(ch, max_wct)),
                 max_core_count,
             )
         run_time = min(ch / core_count, max_wct)
@@ -151,6 +154,25 @@ def confine_wct_node_parameters(
 def convert_to_wct(run_time):
     """Converts the run time (in hours) to a wall clock string"""
     return "{0:02.0f}:{1:02.0f}:00".format(*divmod(run_time * 60, 60))
+
+
+def est_min_ncores_LF(data: np.ndarray):
+    """
+    Estimate the minimum number of cores required to run based on memory requirements per grid point
+    :param data: The data to use to estimate the number of cores required
+    :return: The estimated number of cores required
+    """
+    mem_cap_per_core = 1.5  # In Gb
+    mem_per_gp = 20 * 4 / 1e9  # In Gb
+    n_grid_points = data[:, 0] * data[:, 1] * data[:, 2]
+
+    # Estimate the number of cores required for memory
+    n_cores = np.ceil(mem_per_gp * n_grid_points / mem_cap_per_core)
+
+    # Ensure we scale up to fill a full node
+    n_cores = np.ceil(n_cores / PHYSICAL_NCORES_PER_NODE) * PHYSICAL_NCORES_PER_NODE
+
+    return n_cores
 
 
 def est_LF_chours_single(
@@ -264,7 +286,9 @@ def estimate_LF_chours(
         wct > (node_time_th_factor * data[:, -1] / PHYSICAL_NCORES_PER_NODE)
     ):
         # Want to scale, and at least one job exceeds the allowable time for the given number of cores
-        return scale_core_hours(core_hours, data, node_time_th_factor)
+        ch, _, _ = scale_core_hours(core_hours, data, node_time_th_factor)
+        est_ncores = est_min_ncores_LF(data)
+        return ch, ch / est_ncores, est_ncores
     else:
         return core_hours, core_hours / data[:, -1], (data[:, -1])
 

--- a/workflow/automation/estimation/estimate_wct.py
+++ b/workflow/automation/estimation/estimate_wct.py
@@ -132,12 +132,12 @@ def confine_wct_node_parameters(
             f"Job parameters total ch ({core_count * run_time}) below minimum core-hour bounds ({max_core_hours}). "
             f"Reducing wall clock time to fit."
         )
-        run_time = min(ch / core_count, max_wct)
         if not preserve_core_count:
             core_count = min(
                 scale_cc(ch, max_wct),
                 max_core_count,
             )
+        run_time = min(ch / core_count, max_wct)
 
     if run_time < min_wct:
         run_time = min_wct

--- a/workflow/automation/submit/submit_emod3d.py
+++ b/workflow/automation/submit/submit_emod3d.py
@@ -166,6 +166,7 @@ def get_lf_cores_and_wct(
     ncores, wct = estimate_wct.confine_wct_node_parameters(
         est_cores,
         est_run_time_scaled,
+        min_core_count=est_cores,
         preserve_core_count=(retries is not None and int(retries) > 0),
         hyperthreaded=const.ProcessType.EMOD3D.is_hyperth,
         can_checkpoint=True,  # hard coded for now as this is not available programatically

--- a/workflow/automation/tests/test_estimation/test_estimation.py
+++ b/workflow/automation/tests/test_estimation/test_estimation.py
@@ -96,6 +96,7 @@ MAX_JOB_WCT = qconfig[config.ConfigKeys.MAX_JOB_WCT.name]
 MAX_NODES_PER_JOB = qconfig[config.ConfigKeys.MAX_NODES_PER_JOB.name]
 PHYSICAL_NCORES_PER_NODE = qconfig[config.ConfigKeys.cores_per_node.name]
 MAX_CH_PER_JOB = qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
+CH_SAFTEY_FACTOR = 1.5
 
 
 @pytest.mark.parametrize(
@@ -104,12 +105,12 @@ MAX_CH_PER_JOB = qconfig[config.ConfigKeys.MAX_CH_PER_JOB.name]
         (
             (PHYSICAL_NCORES_PER_NODE * 2, MAX_JOB_WCT / 2),
             PHYSICAL_NCORES_PER_NODE * 2,
-            MAX_JOB_WCT / 2,
+            MAX_JOB_WCT / (2 / CH_SAFTEY_FACTOR),
         ),
         (
             (PHYSICAL_NCORES_PER_NODE, MAX_JOB_WCT + 1),
             PHYSICAL_NCORES_PER_NODE * 2,
-            (MAX_JOB_WCT + 1) / 2,
+            (MAX_JOB_WCT + 1) / (2 / CH_SAFTEY_FACTOR),
         ),
         (
             (PHYSICAL_NCORES_PER_NODE * MAX_NODES_PER_JOB * 2, MAX_JOB_WCT / 2),
@@ -140,7 +141,7 @@ def test_confine_wct_node_parameters(in_params, out_count, out_time):
         cores_per_node=PHYSICAL_NCORES_PER_NODE,
         hyperthreaded=False,
         can_checkpoint=True,
-        ch_safety_factor=1.0,
+        ch_safety_factor=CH_SAFTEY_FACTOR,
     )
 
     assert np.isclose(test_count, out_count)


### PR DESCRIPTION
Adds estimation for the number of cores required to have sufficient memory for LF.

An investigation was taken place to find how much memory each gird point took to use as an estimate. Below is a plot that shows the distribution for memory per grid point for all of the cores for a single LF run. They tend to be somewhere between 125 and 126 bytes. To be safe a value of 150 bytes was chosen per grid point.
![image](https://github.com/ucgmsim/slurm_gm_workflow/assets/33056240/ba3fee01-055e-4236-8be2-118d5d2a02b9)

A minimum core count was added to the confine_wct_node_parameters function to ensure that there is that amount of cores for LF to ensure it's possible to run.

Currently running a test case on Maui to ensure it works as expected, will wait for those to pass before pushing this through to make sure it works. Also requires https://github.com/ucgmsim/qcore/pull/293 and this is why the current check fail due to not finding the memory_per_core in the machine configs