### PR TITLE
Enforced missing log msgs to stdout

### DIFF
--- a/workflow/automation/execution_scripts/add_to_mgmt_queue.py
+++ b/workflow/automation/execution_scripts/add_to_mgmt_queue.py
@@ -97,7 +97,8 @@ if __name__ == "__main__":
         if args.wct is not None
         else None
     )
-    add_to_queue(
+    # When this script is executed, it can't utilize the add_to_queue()'s logger
+    msg = add_to_queue(
         args.queue_folder,
         args.run_name,
         const.ProcessType.from_str(args.proc_type).value,
@@ -111,3 +112,4 @@ if __name__ == "__main__":
         memory=args.memory,
         wct=wct,
     )
+    print(msg)

--- a/workflow/automation/lib/shared_automated_workflow.py
+++ b/workflow/automation/lib/shared_automated_workflow.py
@@ -91,7 +91,7 @@ def add_to_queue(
             os.path.basename(filename)
         )
         ret_msg += msg
-        logger.log(qclogging.NOPRINTCRITICAL,msg)
+        logger.log(qclogging.NOPRINTCRITICAL, msg)
         raise Exception(msg)
 
     msg = "Writing update file to {}".format(filename)

--- a/workflow/automation/lib/shared_automated_workflow.py
+++ b/workflow/automation/lib/shared_automated_workflow.py
@@ -74,7 +74,8 @@ def add_to_queue(
     ret_msg = ""
     """Adds an update entry to the queue"""
     msg = "Adding task to the queue. Realisation: {}, process type: {}, status: {}, job_id: {}, error: {}".format(
-        run_name, proc_type, status, job_id, error)
+        run_name, proc_type, status, job_id, error
+    )
     ret_msg += msg
     logger.debug(msg)
 
@@ -87,10 +88,10 @@ def add_to_queue(
 
     if os.path.exists(filename):
         msg = "An update with the name {} already exists. This should never happen. Quitting!".format(
-            os.path.basename(filename))
+            os.path.basename(filename)
+        )
         ret_msg += msg
-        logger.log(
-            qclogging.NOPRINTCRITICAL,msg)
+        logger.log(qclogging.NOPRINTCRITICAL,msg)
         raise Exception(msg)
 
     msg = "Writing update file to {}".format(filename)
@@ -125,6 +126,7 @@ def add_to_queue(
     ret_msg += msg
 
     return ret_msg
+
 
 def check_mgmt_queue(
     queue_entries: List[str],

--- a/workflow/automation/lib/shared_automated_workflow.py
+++ b/workflow/automation/lib/shared_automated_workflow.py
@@ -71,12 +71,13 @@ def add_to_queue(
     wct: int = None,
     logger: Logger = qclogging.get_basic_logger(),
 ):
+    ret_msg = ""
     """Adds an update entry to the queue"""
-    logger.debug(
-        "Adding task to the queue. Realisation: {}, process type: {}, status: {}, job_id: {}, error: {}".format(
-            run_name, proc_type, status, job_id, error
-        )
-    )
+    msg = "Adding task to the queue. Realisation: {}, process type: {}, status: {}, job_id: {}, error: {}".format(
+        run_name, proc_type, status, job_id, error)
+    ret_msg += msg
+    logger.debug(msg)
+
     filename = os.path.join(
         queue_folder,
         "{}.{}.{}".format(
@@ -85,19 +86,16 @@ def add_to_queue(
     )
 
     if os.path.exists(filename):
+        msg = "An update with the name {} already exists. This should never happen. Quitting!".format(
+            os.path.basename(filename))
+        ret_msg += msg
         logger.log(
-            qclogging.NOPRINTCRITICAL,
-            "An update with the name {} already exists. This should never happen. Quitting!".format(
-                os.path.basename(filename)
-            ),
-        )
-        raise Exception(
-            "An update with the name {} already exists. This should never happen. Quitting!".format(
-                os.path.basename(filename)
-            )
-        )
+            qclogging.NOPRINTCRITICAL,msg)
+        raise Exception(msg)
 
-    logger.debug("Writing update file to {}".format(filename))
+    msg = "Writing update file to {}".format(filename)
+    ret_msg += msg
+    logger.debug(msg)
 
     with open(filename, "w") as f:
         json.dump(
@@ -119,10 +117,14 @@ def add_to_queue(
         )
 
     if not os.path.isfile(filename):
-        logger.critical("File {} did not successfully write".format(filename))
+        msg = "File {} did not successfully write".format(filename)
+        logger.critical(msg)
     else:
-        logger.debug("Successfully wrote task update file")
+        msg = "Successfully wrote task update file"
+        logger.debug(msg)
+    ret_msg += msg
 
+    return ret_msg
 
 def check_mgmt_queue(
     queue_entries: List[str],


### PR DESCRIPTION
When add_to_mgmt_queue.py is called from Slurm/PBS script, the logger add_to_queue() tied to master_log_*.txt file in the cybershake root directory is not accessible. So a status change triggered by the script is never logged. 

The idea was to print these messages to stdout. Then the .out file from the scheduler job should have these log messages.

Here is a question: by default, a basic logger (= qclogging.get_basic_logger() ) is used, but no idea where the output goes to.
I tried to use get_logger() with stdout_printer switch option, but to no avail.

Instead, I devised this quick and dirty solution. Any suggestions welcome.

At least, I get thse messages and I know the update files are indeed written to where it is supposed to.
```
(python3_nurion) x2568a07@login04: /scratch/x2568a02/UC/RunFolder/Cybershake/v23p8/Runs/Torlesse/Torlesse_REL23> cat hf.Torlesse_REL*_20230807_103837_13335963.out
2023-08-07_13:21:49
Adding task to the queue. Realisation: Torlesse_REL23, process type: 4, status: 3, job_id: 13335963, error: None
Writing update file to /scratch/x2568a02/UC/RunFolder/Cybershake/v23p8/mgmt_db_queue/20230807132204_911213.Torlesse_REL23.4
Successfully wrote task update file

2023-08-07_13:22:16
Adding task to the queue. Realisation: Torlesse_REL23, process type: 4, status: 5, job_id: 13335963, error: None
Writing update file to /scratch/x2568a02/UC/RunFolder/Cybershake/v23p8/mgmt_db_queue/20230807132320_403039.Torlesse_REL23.4
Successfully wrote task update file

```

