### PR TITLE
Minor changes to templates

### DIFF
--- a/workflow/automation/templates/run_emod3d.sl.template
+++ b/workflow/automation/templates/run_emod3d.sl.template
@@ -24,7 +24,7 @@ echo $end_time
 
 #run test script and update mgmt_db
 #test before update
-ln -s {{sim_dir}}/LF/e3d.par {{sim_dir}}/LF/OutBin/e3d.par
+ln -sf {{sim_dir}}/LF/e3d.par {{sim_dir}}/LF/OutBin/e3d.par
 timestamp=`date +%Y%m%d_%H%M%S`
 res=`$gmsim/workflow/workflow/calculation/verification/test_emod3d.sh {{sim_dir}} {{srf_name}}`
 success=$?

--- a/workflow/automation/templates/run_hf_mpi.sl.template
+++ b/workflow/automation/templates/run_hf_mpi.sl.template
@@ -1,4 +1,5 @@
 #
+SUCCESS_CODE=0
 
 #updating the stats in managementDB
 if [[ ! -d {{mgmt_db_location}}/mgmt_db_queue ]]; then
@@ -19,7 +20,8 @@ echo $end_time
 timestamp=`date +%Y%m%d_%H%M%S`
 #test before update
 res=`$gmsim/workflow/workflow/calculation/verification/{{test_hf_script}} {{sim_dir}} `
-if [[ $? == 0 ]]; then
+success=$?
+if [[ $success == $SUCCESS_CODE ]]; then
     #passed
     python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py {{mgmt_db_location}}/mgmt_db_queue {{srf_name}} HF completed $SLURM_JOB_ID --end_time "$end_time"
 


### PR DESCRIPTION
1. `ln -sf` ensures the symbolic link is created even if such a link already exists. This line often caused an error
2. The exit value "$?" is best assigned to a separate variable as the value gets lost when another line gets executed before the value is evaluated/checked.  Not a must in the current context, but I was debugging an HF issue with a few added lines in the script, and this "volatile" nature of $? gave me some time of confusion. 
