### PR TITLE
Enforces absolute path to prevent file/directory not-found-issues

### DIFF
--- a/workflow/automation/install_scripts/install_cybershake.py
+++ b/workflow/automation/install_scripts/install_cybershake.py
@@ -126,7 +126,7 @@ def main():
 
     fault_selection = formats.load_fault_selection_file(args.fault_selection_list)
 
-    cybershake_root = args.cybershake_root
+    cybershake_root = Path(args.cybershake_root).resolve()
     runs_dir = simulation_structure.get_runs_dir(cybershake_root)
     create_mgmt_db.create_mgmt_db(
         [],
@@ -145,7 +145,7 @@ def main():
 
     root_params = generate_root_params(
         args.version,
-        args.stat_file_path,
+        Path(args.stat_file_path).resolve(),
         cybershake_root,
         seed=args.seed,
         logger=logger,


### PR DESCRIPTION
When the user input for cybershake_root or stat_file_path are relative paths, it may run into issues.

The former was the root cause of the recent issue of HF job status not getting transitioned to Running or Completed. 
The latter results in root_params.yaml with a relative path for stat/vs30 files, and the workflow will be unable to locate these data files.

This fix enforces to obtain the full absolute path.
