### PR TITLE
Skip loading sim_/fault_/vm_params when not ready

### DIFF
--- a/workflow/automation/metadata/log_metadata.py
+++ b/workflow/automation/metadata/log_metadata.py
@@ -206,9 +206,20 @@ def main(args):
         )
         metadata_dict[const.MetadataField.run_time.value] = tdelta.total_seconds()
 
+    # Skip loading sim_params/fault_params/vm_params, as there are yet to exist
+    if args.proc_type in [
+        const.ProcessType.SRF_GEN.str_value,
+        const.ProcessType.INSTALL_REALISATION.str_value,
+        const.ProcessType.VM_PARAMS.str_value,
+        const.ProcessType.VM_GEN.str_value,
+        const.ProcessType.VM_PERT.str_value,
+        const.ProcessType.NO_VM_PERT.str_value,
+    ]:
+        return
     # Load the params
     params = utils.load_sim_params(
-        os.path.join(args.sim_dir, "sim_params.yaml"), load_vm=True
+        os.path.join(args.sim_dir, "sim_params.yaml"),
+        load_vm=True,
     )
 
     if "dt" in params["bb"]:

--- a/workflow/automation/metadata/log_metadata.py
+++ b/workflow/automation/metadata/log_metadata.py
@@ -207,7 +207,7 @@ def main(args):
         metadata_dict[const.MetadataField.run_time.value] = tdelta.total_seconds()
 
     # Skip loading sim_params/fault_params/vm_params, as there are yet to exist
-    if args.proc_type in [
+    if args.proc_type not in [
         const.ProcessType.SRF_GEN.str_value,
         const.ProcessType.INSTALL_REALISATION.str_value,
         const.ProcessType.VM_PARAMS.str_value,
@@ -215,55 +215,54 @@ def main(args):
         const.ProcessType.VM_PERT.str_value,
         const.ProcessType.NO_VM_PERT.str_value,
     ]:
-        return
-    # Load the params
-    params = utils.load_sim_params(
-        os.path.join(args.sim_dir, "sim_params.yaml"),
-        load_vm=True,
-    )
+        # Load the params
+        params = utils.load_sim_params(
+            os.path.join(args.sim_dir, "sim_params.yaml"),
+            load_vm=True,
+        )
 
-    if "dt" in params["bb"]:
-        bb_dt = params["bb"]["dt"]
-    else:
-        bb_dt = min(params["dt"], params["hf"]["dt"])
+        if "dt" in params["bb"]:
+            bb_dt = params["bb"]["dt"]
+        else:
+            bb_dt = min(params["dt"], params["hf"]["dt"])
 
-    # params metadata for LF
-    if args.proc_type == const.ProcessType.EMOD3D.str_value:
-        metadata_dict[const.MetadataField.nt.value] = int(
-            float(params["sim_duration"]) / float(params["dt"])
-        )
-        metadata_dict[const.MetadataField.nx.value] = params["nx"]
-        metadata_dict[const.MetadataField.ny.value] = params["ny"]
-        metadata_dict[const.MetadataField.nz.value] = params["nz"]
-    # HF
-    elif args.proc_type == const.ProcessType.HF.str_value:
-        metadata_dict[const.MetadataField.nt.value] = int(
-            float(params["sim_duration"]) / float(params["hf"]["dt"])
-        )
-        metadata_dict[const.MetadataField.nsub_stoch.value] = get_nsub_stoch(
-            params["hf"]["slip"], get_area=False
-        )
-    # BB
-    elif args.proc_type == const.ProcessType.BB.str_value:
-        metadata_dict[const.MetadataField.dt.value] = bb_dt
-    # IM_calc
-    elif args.proc_type == const.ProcessType.IM_calculation.str_value:
-        metadata_dict[const.MetadataField.nt.value] = int(
-            float(params["sim_duration"]) / float(bb_dt)
-        )
-        # This should come from a constants file
-        im_calc_csv_file = os.path.join(
-            args.sim_dir, "IM_calc", "{}.csv".format(os.path.basename(args.sim_dir))
-        )
-        im_comp = list(pd.read_csv(im_calc_csv_file).component.unique().astype("U"))
+        # params metadata for LF
+        if args.proc_type == const.ProcessType.EMOD3D.str_value:
+            metadata_dict[const.MetadataField.nt.value] = int(
+                float(params["sim_duration"]) / float(params["dt"])
+            )
+            metadata_dict[const.MetadataField.nx.value] = params["nx"]
+            metadata_dict[const.MetadataField.ny.value] = params["ny"]
+            metadata_dict[const.MetadataField.nz.value] = params["nz"]
+        # HF
+        elif args.proc_type == const.ProcessType.HF.str_value:
+            metadata_dict[const.MetadataField.nt.value] = int(
+                float(params["sim_duration"]) / float(params["hf"]["dt"])
+            )
+            metadata_dict[const.MetadataField.nsub_stoch.value] = get_nsub_stoch(
+                params["hf"]["slip"], get_area=False
+            )
+        # BB
+        elif args.proc_type == const.ProcessType.BB.str_value:
+            metadata_dict[const.MetadataField.dt.value] = bb_dt
+        # IM_calc
+        elif args.proc_type == const.ProcessType.IM_calculation.str_value:
+            metadata_dict[const.MetadataField.nt.value] = int(
+                float(params["sim_duration"]) / float(bb_dt)
+            )
+            # This should come from a constants file
+            im_calc_csv_file = os.path.join(
+                args.sim_dir, "IM_calc", "{}.csv".format(os.path.basename(args.sim_dir))
+            )
+            im_comp = list(pd.read_csv(im_calc_csv_file).component.unique().astype("U"))
 
-        metadata_dict[const.MetadataField.im_comp.value] = im_comp
-        metadata_dict[const.MetadataField.im_comp_count.value] = len(im_comp)
-    # Advanced_IM
-    elif args.proc_type == const.ProcessType.advanced_IM.str_value:
-        metadata_dict[const.MetadataField.nt.value] = int(
-            float(params["sim_duration"]) / float(bb_dt)
-        )
+            metadata_dict[const.MetadataField.im_comp.value] = im_comp
+            metadata_dict[const.MetadataField.im_comp_count.value] = len(im_comp)
+        # Advanced_IM
+        elif args.proc_type == const.ProcessType.advanced_IM.str_value:
+            metadata_dict[const.MetadataField.nt.value] = int(
+                float(params["sim_duration"]) / float(bb_dt)
+            )
 
     store_metadata(
         log_dir, args.proc_type, metadata_dict, sim_name=os.path.basename(args.sim_dir)


### PR DESCRIPTION
When a step in pre-processing gets executed (eg. srf_gen), some of *-params.yaml files are yet to be produced. But they are designed to be loaded in a cascade. and crash if there is one missing.

This fix will determine if the type of params.yaml should be loaded to perform a specified process type, and skip if not present.