### PR TITLE
Use the system defined max wct if the estimated wallclock exceeds it

### DIFF
--- a/workflow/automation/lib/shared_template.py
+++ b/workflow/automation/lib/shared_template.py
@@ -7,7 +7,7 @@ import qcore.constants as const
 from qcore.utils import load_sim_params
 from workflow.automation.lib.schedulers.scheduler_factory import Scheduler
 from workflow.automation.platform_config import platform_config
-
+from qcore import config
 
 def write_sl_script(
     write_directory,
@@ -133,6 +133,9 @@ def resolve_header(
         template_path = platform_config[const.PLATFORM_CONFIG.HEADER_FILE.name]
 
     j2_env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True)
+
+    wallclock_limit = min(wallclock_limit, str(config.qconfig[config.ConfigKeys.MAX_JOB_WCT.name]))
+
     header = j2_env.get_template(template_path).render(
         version=version,
         job_description=job_description,


### PR DESCRIPTION
This change is probably not essential, but I had this bit added to the KISTI workflos codebass sometime. When a wallclock time is estimated, this gets compared with the system's maximum allowed wall clock time and goes with the less value.