### PR TITLE
Query todo2

### DIFF
--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -147,7 +147,7 @@ def get_all_entries(db, run_name, query_mode):
 def get_all_entries_from_config(config_file, db, query_mode):
     extra_query = ""
     if query_mode.todo:
-        extra_query = """AND status_enum.state = 'created'"""
+        extra_query = """AND status_enum.state != 'completed'"""
     elif query_mode.retry_max:
         extra_query = RETRY_MAX_FILTER
     tasks_n, tasks_to_match, tasks_to_not_match = parse_config_file(config_file)

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -187,9 +187,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         tasks = [i.value for i in tasks]
         status.extend(
             db.execute(
-                base_command.format(
-                    "s.run_name LIKE ?", ",?" * (len(tasks) - 1)
-                ),
+                base_command.format("s.run_name LIKE ?", ",?" * (len(tasks) - 1)),
                 (pattern, *tasks),
             ).fetchall()
         )
@@ -197,9 +195,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         tasks = [i.value for i in tasks]
         status.extend(
             db.execute(
-                base_command.format(
-                    "s.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)
-                ),
+                base_command.format("s.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)),
                 (pattern, *tasks),
             ).fetchall()
         )

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -144,7 +144,8 @@ def get_all_entries(db, run_name, query_mode):
                         ORDER BY s.run_name, pe.proc_type, se.state"""
 
     db.execute(
-        base_command, (run_name,),
+        base_command,
+        (run_name,),
     )
     status = db.fetchall()
     return status

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -128,8 +128,8 @@ def get_all_entries(db, run_name, query_mode):
         extra_query = """AND NOT EXISTS (
         SELECT 1 FROM state s_inner
         WHERE s_inner.run_name = state.run_name AND s_inner.proc_type = state.proc_type AND s_inner.status = 5)
-        AND (s.job_id, s.last_modified) IN (
-        SELECT MAX(job_id), MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
+        AND s.last_modified IN (
+        SELECT MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
         )
         """
     elif query_mode.retry_max:
@@ -157,8 +157,8 @@ def get_all_entries_from_config(config_file, db, query_mode):
         extra_query = """AND NOT EXISTS (
         SELECT 1 FROM state s_inner
         WHERE s_inner.run_name = s.run_name AND s_inner.proc_type = s.proc_type AND s_inner.status = 5)
-        AND (s.job_id, s.last_modified) IN (
-        SELECT MAX(job_id), MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
+        AND s.last_modified IN (
+        SELECT MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
         )
         """
     elif query_mode.retry_max:

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -125,7 +125,7 @@ def print_run_status(db, run_name, query_mode: QueryModes, config_file=None):
 def get_all_entries(db, run_name, query_mode):
     extra_query = ""
     if query_mode.todo:
-        extra_query = """AND status_enum.state = 'created'"""
+        extra_query = """AND status_enum.state != 'completed'"""
     elif query_mode.retry_max:
         extra_query = RETRY_MAX_FILTER
 

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -144,8 +144,7 @@ def get_all_entries(db, run_name, query_mode):
                         ORDER BY s.run_name, pe.proc_type, se.state"""
 
     db.execute(
-        base_command,
-        (run_name,),
+        base_command, (run_name,),
     )
     status = db.fetchall()
     return status
@@ -179,7 +178,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
     if len(tasks_n) > 0:
         status.extend(
             db.execute(
-                base_command.format(",?" * (len(tasks_n) - 1),""),
+                base_command.format(",?" * (len(tasks_n) - 1), ""),
                 [i.value for i in tasks_n],
             ).fetchall()
         )
@@ -187,7 +186,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         tasks = [i.value for i in tasks]
         status.extend(
             db.execute(
-                base_command.format(",?" * (len(tasks) - 1),"AND s.run_name LIKE ?"),
+                base_command.format(",?" * (len(tasks) - 1), "AND s.run_name LIKE ?"),
                 (*tasks, pattern),
             ).fetchall()
         )
@@ -195,7 +194,9 @@ def get_all_entries_from_config(config_file, db, query_mode):
         tasks = [i.value for i in tasks]
         status.extend(
             db.execute(
-                base_command.format(",?" * (len(tasks) - 1),"AND s.run_name NOT LIKE ?"),
+                base_command.format(
+                    ",?" * (len(tasks) - 1), "AND s.run_name NOT LIKE ?"
+                ),
                 (*tasks, pattern),
             ).fetchall()
         )

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -17,8 +17,8 @@ RETRY_MAX_FILTER = """AND (SELECT count(*)
                     FROM state as state2, status_enum as status_enum2 
                     WHERE state2.status = status_enum2.id 
                     AND status_enum2.state <> 'failed' 
-                    AND state2.run_name = state.run_name 
-                    AND state.proc_type = state2.proc_type)
+                    AND state2.run_name = s.run_name
+                    AND s.proc_type = state2.proc_type)
                  = 0"""
 
 
@@ -125,19 +125,26 @@ def print_run_status(db, run_name, query_mode: QueryModes, config_file=None):
 def get_all_entries(db, run_name, query_mode):
     extra_query = ""
     if query_mode.todo:
-        extra_query = """AND status_enum.state != 'completed'"""
+        extra_query = """AND NOT EXISTS (
+        SELECT 1 FROM state s_inner
+        WHERE s_inner.run_name = state.run_name AND s_inner.proc_type = state.proc_type AND s_inner.status = 5)
+        AND (s.job_id, s.last_modified) IN (
+        SELECT MAX(job_id), MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
+        )
+        """
     elif query_mode.retry_max:
         extra_query = RETRY_MAX_FILTER
+    base_command = f"""SELECT s.run_name, pe.proc_type, se.state, s.job_id, datetime(last_modified,'unixepoch') lm_time
+                        FROM state s
+                        JOIN status_enum se ON s.status = se.id
+                        JOIN proc_type_enum pe ON s.proc_type = pe.id
+                        WHERE
+                        UPPER(s.run_name) LIKE UPPER(?)
+                        {extra_query}
+                        ORDER BY s.run_name, pe.proc_type, se.state"""
 
     db.execute(
-        f"""SELECT state.run_name, proc_type_enum.proc_type, status_enum.state, state.job_id, datetime(last_modified,'unixepoch')
-                FROM state, status_enum, proc_type_enum
-                WHERE state.proc_type = proc_type_enum.id 
-                AND state.status = status_enum.id
-                AND UPPER(state.run_name) LIKE UPPER(?)
-                {extra_query}
-                ORDER BY state.run_name, status_enum.id
-                """,
+        base_command,
         (run_name,),
     )
     status = db.fetchall()
@@ -147,20 +154,27 @@ def get_all_entries(db, run_name, query_mode):
 def get_all_entries_from_config(config_file, db, query_mode):
     extra_query = ""
     if query_mode.todo:
-        extra_query = """AND status_enum.state != 'completed'"""
+        extra_query = """AND NOT EXISTS (
+        SELECT 1 FROM state s_inner
+        WHERE s_inner.run_name = s.run_name AND s_inner.proc_type = s.proc_type AND s_inner.status = 5)
+        AND (s.job_id, s.last_modified) IN (
+        SELECT MAX(job_id), MAX(last_modified) FROM state WHERE run_name = s.run_name AND proc_type = s.proc_type
+        )
+        """
     elif query_mode.retry_max:
         extra_query = RETRY_MAX_FILTER
     tasks_n, tasks_to_match, tasks_to_not_match = parse_config_file(config_file)
     status = []
 
-    base_command = f""" SELECT state.run_name, proc_type_enum.proc_type, status_enum.state, state.job_id, datetime(last_modified,'unixepoch')
-                        FROM state, status_enum, proc_type_enum
-                        WHERE state.proc_type = proc_type_enum.id 
-                        AND state.status = status_enum.id
+    base_command = f""" SELECT s.run_name, pe.proc_type, se.state, s.job_id, datetime(last_modified,'unixepoch') lm_time
+                        FROM state s
+                        JOIN status_enum se ON s.status = se.id
+                        JOIN proc_type_enum pe ON s.proc_type = pe.id
+                        WHERE
                         {{}}
-                        AND state.proc_type IN (?{{}})
+                        AND s.proc_type IN (?{{}})
                         {extra_query}
-                        ORDER BY state.run_name, status_enum.id"""
+                        ORDER BY s.run_name, pe.proc_type, se.state"""
 
     if len(tasks_n) > 0:
         status.extend(
@@ -174,7 +188,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         status.extend(
             db.execute(
                 base_command.format(
-                    "AND state.run_name LIKE ?", ",?" * (len(tasks) - 1)
+                    "s.run_name LIKE ?", ",?" * (len(tasks) - 1)
                 ),
                 (pattern, *tasks),
             ).fetchall()
@@ -184,7 +198,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         status.extend(
             db.execute(
                 base_command.format(
-                    "AND state.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)
+                    "AND s.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)
                 ),
                 (pattern, *tasks),
             ).fetchall()
@@ -311,16 +325,16 @@ def show_all_error_entries(db, run_name, max_retries=False):
     if max_retries:
         extra_query = RETRY_MAX_FILTER
     db.execute(
-        """SELECT state.run_name, proc_type_enum.proc_type, status_enum.state, state.job_id, datetime(last_modified,'unixepoch'), error.error
-            FROM state, status_enum, proc_type_enum, error
-            WHERE state.proc_type = proc_type_enum.id 
-            AND state.status = status_enum.id
-            AND UPPER(state.run_name) LIKE UPPER(?) 
-            AND error.task_id = state.id
+        """SELECT s.run_name, pe.proc_type, se.state, s.job_id, datetime(last_modified,'unixepoch') lm_time, e.error
+            FROM state s
+            JOIN status_enum se ON s.status = se.id
+            JOIN proc_type_enum pe ON s.proc_type = pe.id
+            JOIN error e ON s.id = e.task_id
+            WHERE UPPER(s.run_name) LIKE UPPER(?) 
             """
         + extra_query
         + """
-            ORDER BY state.run_name, status_enum.id
+            ORDER BY s.run_name, se.id
         """,
         (run_name,),
     )
@@ -363,7 +377,7 @@ def print_mode_help():
               Filters the tasks that have reached the retry count
               Cannot be used with count / todo
           Todo:
-              Filters the tasks that are in the created state
+              Prints out all the non-complete tasks - only shows the latest status
               Cannot be used with retry max
              """
     )

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -198,7 +198,7 @@ def get_all_entries_from_config(config_file, db, query_mode):
         status.extend(
             db.execute(
                 base_command.format(
-                    "AND s.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)
+                    "s.run_name NOT LIKE ?", ",?" * (len(tasks) - 1)
                 ),
                 (pattern, *tasks),
             ).fetchall()


### PR DESCRIPTION
This is an intended duplicate of https://github.com/ucgmsim/slurm_gm_workflow/pull/492
After you approved the other PR, I merged master into the query_todo branch, which caused a bad merge conflict, made things quite mesy. I found it was easier to start a new branch...

-----------
query_mgmt_db.py --mode todo is supposed to give a list of jobs that still need to be done. I think it makes more sense if it shows everything that hasn't reached "completed" status.

---
Updated the query logic.
Without todo mode, you will see

...
               MS04_REL29 |          EMOD3D |     failed | 13251611 |  2023-07-19 01:12:08
               MS04_REL29 |          EMOD3D |     failed | 13336848 |  2023-08-08 21:40:48
               MS04_REL30 |          EMOD3D |     failed | 13251613 |  2023-07-19 01:12:08
               MS04_REL30 |          EMOD3D |     failed | 13336849 |  2023-08-08 21:40:48
               MS09_REL01 |          EMOD3D |  completed | 13336850 |  2023-08-08 21:40:48
               MS09_REL01 |          EMOD3D |     failed | 13251615 |  2023-07-19 01:12:08
               MS09_REL02 |          EMOD3D |  completed | 13336852 |  2023-08-08 21:40:48
               MS09_REL02 |          EMOD3D |     failed | 13251617 |  2023-07-19 01:12:08
               MS09_REL03 |          EMOD3D |  completed | 13336853 |  2023-08-08 21:40:48
               MS09_REL03 |          EMOD3D |     failed | 13251619 |  2023-07-19 01:12:08
...
               MS09_REL21 |          EMOD3D |  completed | 13336879 |  2023-08-08 21:40:48
               MS09_REL21 |          EMOD3D |     failed | 13280910 |  2023-07-27 22:53:35
               MS09_REL22 |          EMOD3D |     failed | 13280912 |  2023-07-27 22:53:35
               MS09_REL22 |          EMOD3D |     failed | 13336881 |  2023-08-08 21:40:48
               MS09_REL23 |          EMOD3D |  completed | 13336882 |  2023-08-08 21:40:48
               MS09_REL23 |          EMOD3D |     failed | 13280915 |  2023-07-27 23:04:33
...
         UpperSlope_REL20 |          EMOD3D |    created |     None |  2023-08-07 01:40:09
         UpperSlope_REL20 |          EMOD3D |     failed | 13323625 |  2023-08-06 21:14:48
         UpperSlope_REL21 |          EMOD3D |    created |     None |  2023-08-07 01:40:09
         UpperSlope_REL21 |          EMOD3D |     failed | 13323626 |  2023-08-06 21:14:48
         UpperSlope_REL22 |          EMOD3D |    created |     None |  2023-08-07 01:40:09
         UpperSlope_REL22 |          EMOD3D |     failed | 13323627 |  2023-08-06 21:14:48

With todo mode, you will no longer see a (rel,process_type) combo that has completed somehow.

...
               MS04_REL29 |          EMOD3D |     failed | 13336848 |  2023-08-08 21:40:48
               MS04_REL30 |          EMOD3D |     failed | 13336849 |  2023-08-08 21:40:48
               MS09_REL22 |          EMOD3D |     failed | 13336881 |  2023-08-08 21:40:48
...
         UpperSlope_REL20 |          EMOD3D |    created |     None |  2023-08-07 01:40:09
         UpperSlope_REL21 |          EMOD3D |    created |     None |  2023-08-07 01:40:09
         UpperSlope_REL22 |          EMOD3D |    created |     None |  2023-08-07 01:40:09

It shows the latest non-complete status of each task - We have just one entry per (rel,process_type) combo. This should give a better overview of the what jobs remain to be done.