### PR TITLE
Limit the number of checkpoints to 3

### DIFF
--- a/workflow/automation/submit/submit_emod3d.py
+++ b/workflow/automation/submit/submit_emod3d.py
@@ -66,10 +66,8 @@ def main(
     binary_path = binary_version.get_lf_bin(
         params["emod3d"]["emod3d_version"], target_qconfig["tools_dir"]
     )
-    # use the original estimated run time for determining the checkpoint, or uses a minimum of 3 checkpoints
-    steps_per_checkpoint = int(
-        min(nt / (60.0 * est_run_time) * const.CHECKPOINT_DURATION, nt // 3)
-    )
+    # checkpoint 3 times
+    steps_per_checkpoint = int(nt // 3)
     if write_directory is None:
         write_directory = sim_dir
 


### PR DESCRIPTION
This branch was buried with other things unnoticed for some time.
This change allows upto 3 checkpoints per emod3d run - we noticed checkpointing is happening a bit too often.

We had an IO issue on KISTI - initially anticipated that reducing the frequency could help, hence this fix was made. 
Unfortunately, the IO issue was not completely fixed, and we had to completely turn off the checkpointing to move on. 

However, I still think it makes sense to limit the number of checkpointing to 3.