### PR TITLE
Convert to str before replace() is called

### DIFF
--- a/workflow/automation/install_scripts/install_cybershake.py
+++ b/workflow/automation/install_scripts/install_cybershake.py
@@ -176,8 +176,8 @@ def generate_root_params(
     root_params_dict = utils.load_yaml(
         template_path / constants.ROOT_DEFAULTS_FILE_NAME
     )
-
-    vs30_file_path = stat_file_path.replace(".ll", ".vs30")
+    print(stat_file_path)
+    vs30_file_path = Path(str(stat_file_path).replace(".ll", ".vs30"))
     v1d_full_path = (
         Path(platform_config[constants.PLATFORM_CONFIG.VELOCITY_MODEL_DIR.name])
         / "Mod-1D"

--- a/workflow/automation/install_scripts/install_cybershake.py
+++ b/workflow/automation/install_scripts/install_cybershake.py
@@ -176,7 +176,6 @@ def generate_root_params(
     root_params_dict = utils.load_yaml(
         template_path / constants.ROOT_DEFAULTS_FILE_NAME
     )
-    print(stat_file_path)
     vs30_file_path = Path(str(stat_file_path).replace(".ll", ".vs30"))
     v1d_full_path = (
         Path(platform_config[constants.PLATFORM_CONFIG.VELOCITY_MODEL_DIR.name])


### PR DESCRIPTION

To fix this error:

(python3_maui) baes@maui01: /nesi/nobackup/nesi00213/RunFolder/Validation/Methven$ python $gmsim/workflow/workflow/automation/install_scripts/install_cybershake.py . list.txt 22.2.2.1 --keep_dup_station --stat_file_path geoNet_stats+2023-06-28.ll
Traceback (most recent call last):
  File "/nesi/project/nesi00213/Environments/baes/workflow/workflow/automation/install_scripts/install_cybershake.py", line 213, in <module>
    main()
  File "/nesi/project/nesi00213/Environments/baes/workflow/workflow/automation/install_scripts/install_cybershake.py", line 146, in main
    root_params = generate_root_params(
  File "/nesi/project/nesi00213/Environments/baes/workflow/workflow/automation/install_scripts/install_cybershake.py", line 180, in generate_root_params
    vs30_file_path = stat_file_path.replace(".ll", ".vs30")
