### PR TITLE
Update to Maui/Mahuika environment creation

### DIFF
--- a/workflow/environments/README.md
+++ b/workflow/environments/README.md
@@ -20,7 +20,7 @@ Requirements: Setup github SSH keys for maui,
 
 A user specific environment of workflow, qcore, IMCalc, Empirical Engine and Pre-processing 
 can be created as follows:  
-1) Go to an existing copy of workflow (eg. can be your home) - make sure this copy is up-to-date as we will be using scripts to create the environment
+1) Go to an existing copy of workflow (eg. can be your home) - it is a good idea to update this copy
 2) Navigate to ".../slurm_gm_workflow/workflow/environments/org/nesi"
 3) Load the correct version of Python module. (** IMPORTANT **)
 4) Run   in /nesi/project/nesi00213/Environments/

--- a/workflow/environments/README.md
+++ b/workflow/environments/README.md
@@ -20,7 +20,7 @@ Requirements: Setup github SSH keys for maui,
 
 A user specific environment of workflow, qcore, IMCalc, Empirical Engine and Pre-processing 
 can be created as follows:  
-1) Go to an existing copy of workflow (ie. not /nesi/project/nesi00213/Environments/....)
+1) Go to an existing copy of workflow (eg. can be your home) - make sure this copy is up-to-date as we will be using scripts to create the environment
 2) Navigate to ".../slurm_gm_workflow/workflow/environments/org/nesi"
 3) Load the correct version of Python module. (** IMPORTANT **)
 4) Run   in /nesi/project/nesi00213/Environments/

--- a/workflow/environments/README.md
+++ b/workflow/environments/README.md
@@ -22,7 +22,7 @@ A user specific environment of workflow, qcore, IMCalc, Empirical Engine and Pre
 can be created as follows:  
 1) Go to an existing copy of workflow (eg. can be your home) - it is a good idea to update this copy
 2) Navigate to ".../slurm_gm_workflow/workflow/environments/org/nesi"
-3) Load the correct version of Python module. (** IMPORTANT **)
+3) Load the correct version of Python module. (** IMPORTANT **) (eg. for Python 3.9, try `module load cray-python cray-hdf5-parallel/1.12.2.3`)
 4) Run   in /nesi/project/nesi00213/Environments/
     ```bash
     ./create_env_maui.sh environment_name config_to_use

--- a/workflow/environments/README.md
+++ b/workflow/environments/README.md
@@ -20,9 +20,10 @@ Requirements: Setup github SSH keys for maui,
 
 A user specific environment of workflow, qcore, IMCalc, Empirical Engine and Pre-processing 
 can be created as follows:  
-1) Go to an existing workflow repository
-2) Navigate to ".../slurm_gm_workflow/workflow/environments/org/nesi" 
-3) Run 
+1) Go to an existing copy of workflow (ie. not /nesi/project/nesi00213/Environments/....)
+2) Navigate to ".../slurm_gm_workflow/workflow/environments/org/nesi"
+3) Load the correct version of Python module. (** IMPORTANT **)
+4) Run   in /nesi/project/nesi00213/Environments/
     ```bash
     ./create_env_maui.sh environment_name config_to_use
     ```
@@ -31,11 +32,12 @@ can be created as follows:
     Note: The environment is installed into /nesi/project/nesi00213/Environments/
     so if an environment with the same already exists the script will exit.
 
-4) Check that the script ran to completion without any errors, 
+5) Check that the script ran to completion without any errors, 
 apart from the IM_calculation setup warning and the pip qcore error.
-5) Log into mahuika
-6) Navigate to the new environment, and into the slurm_gm_workflow/workflow/environments/org/nesi
-7) Run
+6) Log into mahuika
+7) Navigate to the new environment, and into the slurm_gm_workflow/workflow/environments/org/nesi
+8) Make sure you load the correct version of Python module. (eg. `module purge --force NeSI;module add NeSI Python/3.9.9-gimkl-2020a` )
+9) Run
     ```bash
     ./create_python_virtenv_mahuika.sh env_path
     ```

--- a/workflow/environments/org/nesi/create_python_virtenv_mahuika.sh
+++ b/workflow/environments/org/nesi/create_python_virtenv_mahuika.sh
@@ -10,10 +10,27 @@ inhouse_pkgs=(qcore IM_calculation Pre-processing Empirical_Engine visualization
 
 # Create virtual environment
 cd ${env_path}
+
+which python
+echo "^ this must be coming from the correct python module"
+
 python3 -m venv --system-site-packages virt_envs/python3_mahuika
 
 # Activate new python env
 source ./virt_envs/python3_mahuika/bin/activate
+which python # this must be coming from the virtual env just created
+echo "^ This must be coming from the virtual env just created"
+python --version
+echo "^ double check the python version"
+
+
+# update pip. python3 come with a v9.0 which is too old.
+python -m pip install --upgrade pip
+
+#pip install --upgrade pip
+which pip 
+echo "^ double check  pip is coming from the new virt_env"
+
 
 # Sanity check
 if [[ `which python` != *"${name}"* && `which pip` != *"${name}"* ]]; then
@@ -22,8 +39,7 @@ if [[ `which python` != *"${name}"* && `which pip` != *"${name}"* ]]; then
     exit
 fi
 
-# update pip. python3 come with a v9.0 which is too old.
-pip install --upgrade pip
+
 pip install --upgrade setuptools
 
 # Install python packages

--- a/workflow/environments/org/nesi/create_python_virtenv_mahuika.sh
+++ b/workflow/environments/org/nesi/create_python_virtenv_mahuika.sh
@@ -12,24 +12,28 @@ inhouse_pkgs=(qcore IM_calculation Pre-processing Empirical_Engine visualization
 cd ${env_path}
 
 which python
+echo "===================================================="
 echo "^ this must be coming from the correct python module"
 
 python3 -m venv --system-site-packages virt_envs/python3_mahuika
 
 # Activate new python env
 source ./virt_envs/python3_mahuika/bin/activate
-which python # this must be coming from the virtual env just created
-echo "^ This must be coming from the virtual env just created"
+which python
+echo "===================================================="
+echo "^ this must be coming from the virtual env just created"
 python --version
+echo "===================================================="
 echo "^ double check the python version"
 
 
-# update pip. python3 come with a v9.0 which is too old.
-python -m pip install --upgrade pip
-
-#pip install --upgrade pip
+# make sure we install a copy of pip in the virtual env
+python -m pip install --upgrade pip #pip install --upgrade pip
 which pip 
+echo "===================================================="
 echo "^ double check  pip is coming from the new virt_env"
+
+exit
 
 
 # Sanity check


### PR DESCRIPTION
Noticed a few issues (or confusion) during Maui/Mahuika env creation and updated manual and scripts accordingly.

1. We need a copy of workflow somewhere (eg. home) to create a new environment. This means, sometimes you need to git clone this repo just to utilize scripts in environments directory, which will create a new environment and git clone another copy of this repo there. Maybe nice to have a separate "create_env"  repo, but it is what it is for now. 

2. When we create a new environment due to Python upgrade, things can be a little confusing
We have to make sure that the correct module of python is loaded before attempting to create a new environment.  I made it more explicit in the README

3. When a new virtual env is created, it doesn't install a new copy of pip. (https://stackoverflow.com/questions/35079438/how-do-i-can-install-pip-inside-virtual-environment) As a result, when a script executes "pip", this will be coming from the system python. The system pip will try to install a package under system's site-packages (which you have no permission). 

It may not be always the case, but on one occasion, I noticed  a latest copy of pip installed under .local after `pip install--upgrade pip`. It seems it found system python's site-packages are not writable, and silently created a .local and installed pip there. When you use this pip to install other packages, I am afraid things can get pretty messy when we want all new packages to be installed under new virt_envs lib/python3.x/site-packages. 
Doing `python -m pip install --upgrade pip` instead of `pip install --upgrade pip` seems to fix this issue.

