### PR TITLE
Vm pert segfault fix

### DIFF
--- a/workflow/automation/org/nesi/vm_pert.sl
+++ b/workflow/automation/org/nesi/vm_pert.sl
@@ -13,7 +13,6 @@ if [[ -n ${CUR_ENV} && ${CUR_HPC} != "mahuika" ]]; then
 fi
 
 module load FFTW
-module load GCC/7.4.0
 
 VM_PARAMS_YAML=${1:?VM_PARAMS_YAML argument missing}
 OUT_DIR=${2:?OUT_DIR argument missing}
@@ -40,6 +39,8 @@ start_time=`date +$runtime_fmt`
 echo $start_time
 
 python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME VM_PERT running $SLURM_JOB_ID --start_time "$start_time" --nodes $SLURM_NNODES --cores $SLURM_CPUS_PER_TASK --wct "$WCT"
+
+module load GCC/7.4.0
 if [ -f $OUT_DIR/$REL_NAME.pertb.csv ]; then
   echo time python $gmsim/Pre-processing/srf_generation/velocity_model_generation/generate_perturbation_file.py $OUT_DIR/$REL_NAME.pertb $VM_PARAMS_YAML -n 1 -v --perturbation --parameter_file $OUT_DIR/$REL_NAME.pertb.csv
   time python $gmsim/Pre-processing/srf_generation/velocity_model_generation/generate_perturbation_file.py $OUT_DIR/$REL_NAME.pertb $VM_PARAMS_YAML -n 1 -v --perturbation --parameter_file $OUT_DIR/$REL_NAME.pertb.csv
@@ -54,6 +55,7 @@ echo $end_time
 
 timestamp=`date +%Y%m%d_%H%M%S`
 #test before update
+module load GCC/9.2.0
 res=`python $gmsim/qcore/qcore/validate_vm.py file $OUT_DIR/$REL_NAME.pertb $VM_PARAMS_YAML`
 pass=$?
 

--- a/workflow/automation/org/nesi/vm_pert.sl
+++ b/workflow/automation/org/nesi/vm_pert.sl
@@ -40,6 +40,10 @@ echo $start_time
 
 python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME VM_PERT running $SLURM_JOB_ID --start_time "$start_time" --nodes $SLURM_NNODES --cores $SLURM_CPUS_PER_TASK --wct "$WCT"
 
+# this step is run on Mahuika and depends on binaries tools from /scale_wlg_persistent/filesets/project/nesi00213/opt/mahuika/tools/GCC740
+# (symlinked to /scale_wlg_persistent/filesets/project/nesi00213/opt/mahuika/hybrid_sim_tools)
+# We have GCC920-built tools but we stick to old ones as random numbers will be different
+
 module load GCC/7.4.0
 if [ -f $OUT_DIR/$REL_NAME.pertb.csv ]; then
   echo time python $gmsim/Pre-processing/srf_generation/velocity_model_generation/generate_perturbation_file.py $OUT_DIR/$REL_NAME.pertb $VM_PARAMS_YAML -n 1 -v --perturbation --parameter_file $OUT_DIR/$REL_NAME.pertb.csv
@@ -55,6 +59,7 @@ echo $end_time
 
 timestamp=`date +%Y%m%d_%H%M%S`
 #test before update
+# Normal Python modules are built with GCC/9.2.0
 module load GCC/9.2.0
 res=`python $gmsim/qcore/qcore/validate_vm.py file $OUT_DIR/$REL_NAME.pertb $VM_PARAMS_YAML`
 pass=$?


### PR DESCRIPTION
VM Pert is meant to be executed on Mahuika and it crashes with a segmentation fault. This fixes one of the causes (the other one has been already addressed: https://github.com/ucgmsim/Pre-processing/pull/227)

This one, in particular, generaets core dumps and GDB tells it was created by validate_vm.py
Further inspection revealed that it was caused by GCC version mismatch.

(details were copied from https://uceqeng.slack.com/archives/C3SGQHXT8/p1700799356822109 and edited)

Since NeSI updated Python to 3.9,  we have to explicily load GCC/7.4.0 module to be able to run Fortran binaries (including combine_pertb as well as SRF,HF and BB calculation) in /nesi/project/nesi00213/opt/mahuika/hybrid_sim_tools 

```
module load GCC/7.4.0
```

Without loading this version of GCC, vm_pert step will crash complaining about libpython39 errors 

However, with GCC/7.4.0 loaded, validate_vm.py indeed crashes with a segmentation fault. It is coming from this import line.
```
Python 3.9.9 (main, Feb  2 2022, 17:29:26) 
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from qcore.srf import get_bounds
Segmentation fault
```

One step deeper into srf.py we can identify this impot line is the root cause.
```
>>> from alphashape import alphashape
Segmentation fault
```

This is because alphashape was built with GCC 9.2.0. In fact, Python 3.9 itself and many of installed modules (via pip install) are built with GCC 9.2.0.

If we switch to GCC/9.2.0 first, alphashape is imported ok.

There are two options to fix.
Option 1. Switch GCC modules between 7.4.0 and 9.2.0 as needed
Option2.  Rebuild everything with GCC/9.2.0

I built all binaries with GCC/9.2.0 and kept them in /scale_wlg_persistent/filesets/project/nesi00213/opt/mahuika/tools/GCC920 for future use, but I propose we go with Option1 for the time being. 

Different compiler means different random number sequences generated even with the same seed. For the sake of reproducibility (especially VM pert depends on random numbers), I think it is best to stick to the old binaries.
