### PR TITLE
Archieve e3d.par during cleanup

### DIFF
--- a/workflow/scripts/clean_up.py
+++ b/workflow/scripts/clean_up.py
@@ -27,7 +27,7 @@ SUBMISSION_SL_LOGS = ["*.pbs", "*.sl", "*.err", "*.out"]
 LF_DIR_NAME = "LF_temp"
 LF_SUB_DIR_NAME = "OutBin"
 LF_TAR = "LF.tar"
-LF_FILES = ["Rlog", "Restart", "SlipOut"]
+LF_FILES = ["Rlog", "Restart", "SlipOut", "e3d.par"]
 
 
 def tar_files(directory_to_tar, archive_name):


### PR DESCRIPTION
When we keep the EMOD3D unchanged, but only BB calculation is different, we could copy the LF.tar produced during clean-up step to a new sim directory, and extracted it there, to re-use the LF result.

However, when a new BB calculation starts, qcore/timeseries.py will search for e3d.par and immediately exit, as that file is missing - it's never been archieved.

I'm proposing to include e3d.par to remedy this.

