### PR TITLE
Fixing "Database is locked" issue

### DIFF
--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -5,6 +5,7 @@ A script that queries a slurm mgmt db and returns the status of a task
 """
 
 import argparse
+import os
 from typing import Union, List
 
 from workflow.automation.lib import MgmtDB
@@ -47,17 +48,27 @@ def state_table_query_builder(
     ordering: Union[bool, str, List[str]] = False,
 ):
     """
-    Creates queries for the state table.
-    For data sanitation reasons variables are passed in separately to the query string (No Bobby tables here)
-    :param what: The columns to be selected
-    :param state: Either true for one, or the number of states to be selected
-    :param process_type: Either true for one, or the number of states to be selected
-    :param run_name_exact: If an exact pattern match is required
-    :param run_name_similar: If a pattern match is required, to be used with '%' as the sqlite wildcard character
-    :param run_name_disimilar: If a pattern non-match is required, to be used with '%' as the sqlite wildcard character
-    :param task_id: Either true for one, or the number of states to be selected
-    :param ordering: The columns to order the results by
-    :return: The string to be used as the query
+    Creates queries for the state table. For data sanitation reasons variables are passed in separately to the query string.
+
+    Parameters
+    ----------
+    what : Union[str, List[str]]
+        The columns to be selected.
+    state : Union[bool, int], optional
+        Either true for one, or the number of states to be selected, by default False.
+    process_type : Union[bool, int], optional
+        Either true for one, or the number of states to be selected, by default False.
+    run_name_type : MgmtDB.ComparisonOperator, optional
+        If an exact pattern match is required, by default None.
+    task_id : Union[bool, int], optional
+        Either true for one, or the number of states to be selected, by default False.
+    ordering : Union[bool, str, List[str]], optional
+        The columns to order the results by, by default False.
+
+    Returns
+    -------
+    str
+        The string to be used as the query.
     """
     if isinstance(what, str):
         what = [what]
@@ -415,10 +426,9 @@ def main():
     if args.mode_help:
         print_mode_help()
         exit()
-    f = args.run_folder
+
     run_name = args.run_name
     mode = args.mode
-    db = MgmtDB.connect_db(f)
 
     query_mode = QueryModes()
     if "error" in mode:
@@ -433,7 +443,11 @@ def main():
     if "retry_max" in mode:
         query_mode.retry_max = True
 
-    print_run_status(db, run_name, query_mode, args.config)
+    with MgmtDB.connect_db_ctx(
+        os.path.join(args.run_folder, "slurm_mgmt.db"),
+        pragmas=["synchronous = EXTRA", "integrity_check"],
+    ) as cur:
+        print_run_status(cur, run_name, query_mode, args.config)
 
 
 if __name__ == "__main__":

--- a/workflow/automation/execution_scripts/query_mgmt_db.py
+++ b/workflow/automation/execution_scripts/query_mgmt_db.py
@@ -5,7 +5,7 @@ A script that queries a slurm mgmt db and returns the status of a task
 """
 
 import argparse
-import os
+from pathlib import Path
 from typing import Union, List
 
 from workflow.automation.lib import MgmtDB
@@ -444,7 +444,7 @@ def main():
         query_mode.retry_max = True
 
     with MgmtDB.connect_db_ctx(
-        os.path.join(args.run_folder, "slurm_mgmt.db"),
+        Path(args.run_folder) / "slurm_mgmt.db",
         pragmas=["synchronous = EXTRA", "integrity_check"],
     ) as cur:
         print_run_status(cur, run_name, query_mode, args.config)

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -439,7 +439,7 @@ class MgmtDB:
         while len(runnable_tasks) < task_limit and offset < entries:
             with connect_db_ctx(self._db_file) as cur:
                 db_tasks = cur.execute(
-                    """SELECT run_name, proc_type 
+                    """SELECT proc_type, run_name 
                               FROM status_enum, state 
                               WHERE state.status = status_enum.id
                                AND proc_type IN (?{})
@@ -451,8 +451,8 @@ class MgmtDB:
                     (*allowed_tasks, allowed_rels, offset),
                 ).fetchall()
             for task in db_tasks:
-                # task is a tuple like ('TaieriR_REL21', 11), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
-                if self._check_dependancy_met(task, logger) and f"{task[0]}__{task[1]}" not in tasks_waiting_for_updates:
+                # task is a tuple like (11, 'TaieriR_REL21'), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
+                if self._check_dependancy_met(task, logger) and f"{task[1]}__{task[0]}" not in tasks_waiting_for_updates:
                     runnable_tasks.append((*task, self.get_retries(*task, get_WCT=True)))
 
             offset += 100

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -452,8 +452,13 @@ class MgmtDB:
                 ).fetchall()
             for task in db_tasks:
                 # task is a tuple like (11, 'TaieriR_REL21'), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
-                if self._check_dependancy_met(task, logger) and f"{task[1]}__{task[0]}" not in tasks_waiting_for_updates:
-                    runnable_tasks.append((*task, self.get_retries(*task, get_WCT=True)))
+                if (
+                    self._check_dependancy_met(task, logger)
+                    and f"{task[1]}__{task[0]}" not in tasks_waiting_for_updates
+                ):
+                    runnable_tasks.append(
+                        (*task, self.get_retries(*task, get_WCT=True))
+                    )
 
             offset += 100
 

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -53,7 +53,11 @@ def connect_db_ctx(db_file, verbose=False):
 
     A commit is run at the end of the context.
     """
-    conn = sql.connect(db_file)
+    # timeout parameter specifies how long the connection should wait for the lock to 
+    # go away until raising an exception. Default is 5 secs
+    # https://stackoverflow.com/a/8618328/2005856
+    # https://docs.python.org/2/library/sqlite3.html#sqlite3.connect
+    conn = sql.connect(db_file, timeout=10)
     if verbose:
         conn.set_trace_callback(print)
 

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -371,7 +371,8 @@ class MgmtDB:
                     "AND status <= (SELECT id FROM status_enum WHERE state = 'completed') ",
                     (run_name, proc_type),
                 ).fetchone()[0]
-                if not_failed_count == 0:
+            if not_failed_count == 0:
+                with connect_db_ctx(self._db_file) as cur:
                     self._insert_task(cur, run_name, proc_type)
 
     def close_conn(self):
@@ -592,8 +593,9 @@ class MgmtDB:
                     """select * from proc_type_enum"""
                 ).fetchall()
 
-                for run_name in realisations:
-                    for proc in procs_to_be_done:
+            for run_name in realisations:
+                for proc in procs_to_be_done:
+                    with connect_db_ctx(self._db_file) as cur:
                         if not self._does_task_exists(cur, run_name, proc[0]):
                             self._insert_task(cur, run_name, proc[0])
 

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -371,8 +371,8 @@ class MgmtDB:
                     "AND status <= (SELECT id FROM status_enum WHERE state = 'completed') ",
                     (run_name, proc_type),
                 ).fetchone()[0]
-            if not_failed_count == 0:
-                self._insert_task(cur, run_name, proc_type)
+                if not_failed_count == 0:
+                    self._insert_task(cur, run_name, proc_type)
 
     def close_conn(self):
         """Close the db connection. Note, this ONLY has to be done if

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -53,7 +53,7 @@ def connect_db_ctx(db_file, verbose=False):
 
     A commit is run at the end of the context.
     """
-    # timeout parameter specifies how long the connection should wait for the lock to 
+    # timeout parameter specifies how long the connection should wait for the lock to
     # go away until raising an exception. Default is 5 secs
     # https://stackoverflow.com/a/8618328/2005856
     # https://docs.python.org/2/library/sqlite3.html#sqlite3.connect
@@ -354,7 +354,6 @@ class MgmtDB:
             if key not in failure_count.keys():
                 failure_count.update({key: {"killed_WCT": 0, "failed": 0}})
             failure_count[key][state] += 1
-
 
         for key, fail_count in failure_count.items():
             if any([x >= n_max_retries for x in fail_count.values()]):

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -451,6 +451,7 @@ class MgmtDB:
                     (*allowed_tasks, allowed_rels, offset),
                 ).fetchall()
             for task in db_tasks:
+                # task is a tuple like (11, 'TaieriR_REL21'), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
                 if self._check_dependancy_met(task, logger) and f"{task[1]}__{task[0]}" not in tasks_waiting_for_updates:
                     runnable_tasks.append((*task, self.get_retries(*task, get_WCT=True)))
 

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -1,6 +1,7 @@
 import datetime
 from contextlib import contextmanager
 from logging import Logger
+from pathlib import Path
 import sqlite3 as sql
 from typing import List, Dict
 from dataclasses import dataclass
@@ -37,7 +38,7 @@ class SchedulerTask:
 
 @contextmanager
 def connect_db_ctx(
-    db_file: str, pragmas: list[str] = [], verbose: bool = False
+    db_file: Path, pragmas: list[str] = [], verbose: bool = False
 ) -> sql.Cursor:
     """
     Connects to the database at the specified path and yields a cursor to be used within a context manager.
@@ -45,7 +46,7 @@ def connect_db_ctx(
 
     Parameters
     ----------
-    db_file: str
+    db_file: Path
         The path to the database
     pragmas: list[str], optional
         A list of PRAGMA statements to be run on the connection
@@ -96,7 +97,7 @@ class MgmtDB:
     col_wct = "WCT"
 
     def __init__(self, db_file: str):
-        self._db_file = db_file
+        self._db_file = Path(db_file)
 
         # This should only be used when doing actions with the intention of
         # leaving the connection open, otherwise use connect_db_ctx with a "with"
@@ -662,7 +663,7 @@ class MgmtDB:
 
     @classmethod
     def init_db(cls, db_file: str, init_script: str):
-        with connect_db_ctx(db_file) as cur:
+        with connect_db_ctx(Path(db_file)) as cur:
             with open(init_script, "r") as f:
                 cur.executescript(f.read())
 

--- a/workflow/automation/lib/MgmtDB.py
+++ b/workflow/automation/lib/MgmtDB.py
@@ -439,7 +439,7 @@ class MgmtDB:
         while len(runnable_tasks) < task_limit and offset < entries:
             with connect_db_ctx(self._db_file) as cur:
                 db_tasks = cur.execute(
-                    """SELECT proc_type, run_name 
+                    """SELECT run_name, proc_type 
                               FROM status_enum, state 
                               WHERE state.status = status_enum.id
                                AND proc_type IN (?{})
@@ -451,8 +451,8 @@ class MgmtDB:
                     (*allowed_tasks, allowed_rels, offset),
                 ).fetchall()
             for task in db_tasks:
-                # task is a tuple like (11, 'TaieriR_REL21'), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
-                if self._check_dependancy_met(task, logger) and f"{task[1]}__{task[0]}" not in tasks_waiting_for_updates:
+                # task is a tuple like ('TaieriR_REL21', 11), tasks_waiting_for_updates is a list of strings like ['TaieriR_REL21__11']
+                if self._check_dependancy_met(task, logger) and f"{task[0]}__{task[1]}" not in tasks_waiting_for_updates:
                     runnable_tasks.append((*task, self.get_retries(*task, get_WCT=True)))
 
             offset += 100

--- a/workflow/automation/tests/test_scripts/test_management/test_mgmt_db.py
+++ b/workflow/automation/tests/test_scripts/test_management/test_mgmt_db.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import shutil
 import pytest
 
@@ -35,7 +36,7 @@ def mgmt_db():
 def get_rows(db_file, table, col_name, col_value, selected_col="*"):
     query = "SELECT {} from {} where {} = ?".format(selected_col, table, col_name)
 
-    with connect_db_ctx(db_file) as cur:
+    with connect_db_ctx(Path(db_file)) as cur:
         rows = cur.execute(query, (col_value,)).fetchall()
     return rows
 

--- a/workflow/e2e_tests/queue_monitor_tests.py
+++ b/workflow/e2e_tests/queue_monitor_tests.py
@@ -1,6 +1,7 @@
 """For stress testing queue_monitor"""
 
 import os
+from pathlib import Path
 import json
 import shutil
 import time
@@ -256,7 +257,7 @@ class QueueMonitorStressTest(object):
 
     def check_mgmt_db_progress(self):
         """Checks auto submit progress in the management db"""
-        with connect_db_ctx(sim_struct.get_mgmt_db(self.stage_dir)) as cur:
+        with connect_db_ctx(Path(sim_struct.get_mgmt_db(self.stage_dir))) as cur:
             comp_count = [
                 cur.execute(
                     "SELECT COUNT(*) "


### PR DESCRIPTION
@sarahjaneneill has been witnessing `database is locked` sqlite3.OperationalError frequently.

```
2024-02-14 02:03:11,935 - queue monitor - squeue tasks: 42576994 PD, 42576995 PD, 42576996 PD,...line 417, in get_runnable_tasks
    entries = cur.execute(
sqlite3.OperationalError: database is locked
2024-02-14 02:03:27,323 - MainThread - The main auto_submit thread has terminated, and all...
```
and this is my attempt to address the issue.

Reference: https://stackoverflow.com/questions/3172929/operationalerror-database-is-locked

I changed the code to release the connection as soon as one transaction is completed. Also gave 10 secs timeout before screaming "database is locked".

Tested by Sarah, and myself - the issue is not happening while burning half million core hours. 