### PR TITLE
Collect estimated time and time actually spent

### DIFF
--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -153,7 +153,7 @@ def main():
         assert job_id is not None, f"{run_name} {proc_type_str}"
         # Execute sacct command
         for machine in ["maui", "mahuika"]:
-            cmd = f'sacct -j {job_id} -M {machine} --format="JobName,time_used,time_requested,AllocCPUS"'
+            cmd = f'sacct -j {job_id} -M {machine} --format="JobName,Elapsed,TimeLimit,AllocCPUS"'
             sacct_output = subprocess.check_output(
                 cmd,
                 shell=True,

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -14,6 +14,7 @@ different from the time used, it may indicate that the wall clock time estimatio
 
 import argparse
 from datetime import datetime, timedelta
+import json
 import pandas as pd
 from pathlib import Path
 import sqlite3
@@ -26,8 +27,9 @@ PROCESS_TYPE = dict([(proc.value, proc.name) for proc in ProcessType])
 REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
 
 DEFAULT_OUTFILE = "est_vs_used_cpu_time.csv"
+CONFIG_JSON = Path(__file__).parents[1]/"org/nesi/config.json"
 
-
+print(CONFIG_JSON)
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Get estimated vs used CPU time for jobs in the database"
@@ -46,8 +48,37 @@ def parse_args():
         default=DEFAULT_OUTFILE,
     )
 
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to the config file",
+        default = CONFIG_JSON
+    )
+
     return parser.parse_args()
 
+def read_config(config_file: Path) -> dict:
+    """
+    Read the config file and return the contents as a dictionary
+    Parameters
+    ----------
+    config_file : Path
+        Path to the config file
+
+    Returns
+    -------
+    config_data : dict
+        A dictionary of the config file contents
+
+    """
+
+    with open(config_file, 'r') as config_file:
+        config_data = json.load(config_file)
+
+    # Extract the MACHINE_TASKS dictionary
+    machine_tasks = config_data.get("MACHINE_TASKS", {})
+    print(machine_tasks)
+    return machine_tasks
 
 def read_realization_list(list_file: Path) -> dict:
     """

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -1,0 +1,160 @@
+import sqlite3
+import subprocess
+import pandas as pd
+import argparse
+from qcore.constants import ProcessType
+from datetime import datetime, timedelta
+from pathlib import Path
+
+PROCESS_TYPE = dict([(proc.value, proc.name) for proc in ProcessType])
+REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
+
+DEFAULT_OUTCSV = "est_vs_used_cpu_time.csv"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate CSV data from SQLite and SLURM"
+    )
+    parser.add_argument("--list", help="Path to the realization list file")
+    parser.add_argument("--update", help="Path to the existing CSV file to update")
+    parser.add_argument(
+        "--outfile", help="Path to the output CSV file", default=DEFAULT_OUTCSV
+    )
+
+    return parser.parse_args()
+
+
+def read_realization_list(list_file):
+    realization_data = {}
+    with open(list_file, "r") as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) == 2:
+                event_name, num_rels = parts
+                realization_data[event_name] = int(
+                    num_rels[:-1]
+                )  # Remove the trailing 'r'
+    return realization_data
+
+
+def convert_elapsed_to_seconds(elapsed_str):
+    # Convert elapsed time from "hh:mm:ss" to total seconds
+    elapsed_time = datetime.strptime(elapsed_str, "%H:%M:%S")
+    elapsed_seconds = timedelta(
+        hours=elapsed_time.hour,
+        minutes=elapsed_time.minute,
+        seconds=elapsed_time.second,
+    ).total_seconds()
+    return elapsed_seconds
+
+
+def main():
+    args = parse_args()
+
+    # Connect to the SQLite database
+    conn = sqlite3.connect("slurm_mgmt.db")
+    cursor = conn.cursor()
+
+    # Query the relevant data
+    cursor.execute(
+        "SELECT run_name, proc_type, job_id FROM state WHERE status = 5 AND proc_type != 20"
+    )
+    rows = cursor.fetchall()
+
+    # Initialize a list to add
+    data_list = []
+
+    # Read realization data from the list file
+    realization_data = read_realization_list(args.list) if args.list else {}
+
+    jobs_from_csv = {}
+    existing_df = None
+
+    if args.update is not None:
+        args.update = Path(args.update)
+        if args.update.exists():
+            existing_df = pd.read_csv(args.update)
+            jobs_from_csv = {
+                (row["run_name"], REVERSE_PROCESS_TYPE[row["proc_type"]]): row["job_id"]
+                for _, row in existing_df.iterrows()
+            }
+
+    jobs_from_db = {(row[0], row[1]): row[2] for row in rows}
+    print(f"Record found in {args.update} : {len(jobs_from_csv.keys())} entries")
+    print(f"Record found in DB : {len(jobs_from_db.keys())} entries")
+
+    jobs_to_add_dict = {
+        (run_name, PROCESS_TYPE[proc_type]): jobs_from_db[(run_name, proc_type)]
+        for run_name, proc_type in list(
+            set(jobs_from_db.keys()) - set(jobs_from_csv.keys())
+        )
+    }
+
+    print(f"Records to add to the CSV: {jobs_to_add_dict}")
+
+    # Iterate over job_ids
+    #    for run_name, proc_type_str,job_id in jobs_to_add_dict.items():
+    for (run_name, proc_type_str), job_id in jobs_to_add_dict.items():
+
+        assert job_id is not None, f"{run_name} {proc_type_str}"
+        # Execute sacct command
+        for machine in ["maui", "mahuika"]:
+            cmd = f'sacct -j {job_id} -M {machine} --format="JobName,Elapsed,TimeLimit,AllocCPUS"'
+            sacct_output = subprocess.check_output(
+                cmd,
+                shell=True,
+            )
+            sacct_lines = sacct_output.decode().splitlines()
+            if len(sacct_lines) >= 3:
+                break  # found the wanted result
+
+        assert (
+            len(sacct_lines) >= 3
+        ), f"{job_id} {sacct_lines} {cmd}"  # make sure the command returned the output we want
+
+        # Extract relevant info from the first row containing numbers
+        try:
+            job_info = sacct_lines[2].split()
+        except IndexError:
+            raise
+        elapsed, timelimit, alloc_cpus = job_info[1], job_info[2], job_info[3]
+
+        # Determine if it's an event (based on run_name)
+        is_event = "_REL" not in run_name  # otherwise, it is a realization
+        num_rels = realization_data.get(run_name, None) if is_event else None
+
+        # Convert elapsed time to seconds
+        elapsed_seconds = convert_elapsed_to_seconds(elapsed)
+
+        # Calculate Corehours_used
+        coreseconds_used = elapsed_seconds * int(alloc_cpus)
+
+        data_list.append(
+            {
+                "run_name": run_name,
+                "proc_type": proc_type_str,
+                "job_id": job_id,
+                "CPUs_used": alloc_cpus,
+                "Time_requested": timelimit,
+                "Time_used": elapsed,
+                "Coreseconds_used": coreseconds_used,
+                "num_rels": num_rels,
+            }
+        )
+
+    # Create a DataFrame from the list of dictionaries
+    df = pd.DataFrame(data_list)
+    if existing_df is not None:
+        updated_df = pd.concat([existing_df, df], ignore_index=True)
+        # Sort by run_name and proc_type
+        updated_df.sort_values(by=["run_name", "proc_type"], inplace=True)
+        df = updated_df
+    # Write to a CSV file
+    df.to_csv(args.outfile, index=False)
+
+    print(f"CSV file {args.outfile} created successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -27,7 +27,8 @@ PROCESS_TYPE = dict([(proc.value, proc.name) for proc in ProcessType])
 REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
 
 DEFAULT_OUTFILE = "est_vs_used_cpu_time.csv"
-CONFIG_JSON = Path(__file__).parents[1]/"org/nesi/config.json"
+CONFIG_JSON = Path(__file__).parents[1] / "org/nesi/config.json"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -48,13 +49,11 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--config",
-        type=Path,
-        help="Path to the config file",
-        default = CONFIG_JSON
+        "--config", type=Path, help="Path to the config file", default=CONFIG_JSON
     )
 
     return parser.parse_args()
+
 
 def proc_type_machine_mapping(config_file: Path) -> dict:
     """
@@ -71,13 +70,14 @@ def proc_type_machine_mapping(config_file: Path) -> dict:
 
     """
     assert config_file.exists(), f"Config file {config_file} does not exist"
-    with open(config_file, 'r') as f:
+    with open(config_file, "r") as f:
         config_data = json.load(f)
 
     # Extract the MACHINE_TASKS dictionary
     proc_type_machine_dict = config_data.get("MACHINE_TASKS", {})
 
     return proc_type_machine_dict
+
 
 def read_realization_list(list_file: Path) -> dict:
     """
@@ -206,7 +206,7 @@ def main():
         # Determine if it's a MEDIAN event (based on run_name)
         is_median_event = "_REL" not in run_name  # otherwise, it is a realization
         num_rels = realization_data.get(run_name, 0) if is_median_event else 0
-        num_rels = 0 if proc_type_str in ["VM_GEN","INSTALL_FAULT"] else num_rels
+        num_rels = 0 if proc_type_str in ["VM_GEN", "INSTALL_FAULT"] else num_rels
 
         # Convert time_used time to seconds
         time_used_seconds = convert_time_used_to_seconds(time_used)

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -178,7 +178,7 @@ def main():
             set(jobs_from_db.keys()) - set(jobs_from_csv.keys())
         )
     }
-    print(f"Records to add to the CSV: {jobs_to_add_dict.keys()[:10]}...")
+    print(f"Records to add to the CSV: {len(jobs_to_add_dict)}")
 
     # Iterate over job_ids
     for (run_name, proc_type_str), job_id in jobs_to_add_dict.items():

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -1,14 +1,17 @@
 """
-Collect estimated vs used CPU time for Cybershake-styled runs
+Collect estimated vs used CPU time for Cybershake-styled runs on NeSI. This only works on Maui/Mahuika running SLURM,
+as it relies on "sacct" command to get the job information.
 
 This is particularly useful to accurately estimate the core hours needed for the entire set of Cybershake-styled
-simulations. One can run the MEDIAN simulations only, and then run this script to collect the estimated core hours and
+simulation. One can run the MEDIAN events only, then run this script to collect the estimated core hours and
 the cpu time actually used.
-By multiplying the time_used by the number of realisations,
-we can accurately estimate the total core hours required to run the entire set of simulations.
+By multiplying the time_used by the number of realisations, we can accurately estimate the total core hours required
+to run the entire set of simulations.
 
 This script is also useful to assess the quality of wall clock time estimation. If the estimated time is significantly
-different from the time used, it may indicate that the wall clock time estimation method needs to be improved.
+different from the time used, it may indicate that the estimation method needs to be improved.
+
+
 
 """
 
@@ -26,6 +29,8 @@ from qcore import simulation_structure
 PROCESS_TYPE = dict([(proc.value, proc.name) for proc in ProcessType])
 REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
 
+machines = ["maui", "mahuika"]
+MEDIAN_ONLY_PROCS = ["VM_GEN", "INSTALL_FAULT", "VM_PARAMS"]
 DEFAULT_OUTFILE = "est_vs_used_cpu_time.csv"
 CONFIG_JSON = Path(__file__).parents[1] / "org/nesi/config.json"
 
@@ -146,19 +151,20 @@ def main():
     rows = cursor.fetchall()
     jobs_from_db = {
         str(row[2]): (row[0], PROCESS_TYPE.get(row[1])) for row in rows
-    }  # job_id : (run_name, proc_type_str)
+    }  # job_id : (run_name, proc_type_str) / ensure job_id is a str
     print(f"Record found in DB : {len(jobs_from_db.keys())} entries")
 
     # Initialize a list to add the data to
     data_list = []
 
     # Read realization data from the list file
+    assert args.list.exists()
     realization_numbers = read_realization_list(args.list) if args.list.exists() else {}
 
-    # Iterate over job_ids
-    machines = ["maui", "mahuika"]
+    # initialize an empty list for each machine in machine_jobs dictionary
     machine_jobs = {machine: [] for machine in machines}
 
+    # Iterate over job_ids collected from DB
     for job_id, (run_name, proc_type_str) in jobs_from_db.items():
         assert job_id is not None, f"{run_name} {proc_type_str}"
         machine = proc_type_machine_dict[proc_type_str]
@@ -166,9 +172,23 @@ def main():
 
     for machine in machines:
         job_ids = ",".join(machine_jobs[machine])
+        # Get the job information from the SLURM database
+        # eg.
+        # $ sacct -j 4088784,4088640 --format="JobID,Elapsed,TimeLimit,AllocCPUS" -n
+        # 4088640        02:10:42   08:17:00        160
+        # 4088640.bat+   02:10:42                    80
+        # 4088640.ext+   02:10:42                   160
+        # 4088640.0      02:10:06                   160
+        # 4088784        00:03:38   00:30:00         80
+        # 4088784.bat+   00:03:38                    80
+        # 4088784.ext+   00:03:38                    80
+        # 4088784.0      00:03:19                    80
+        #
+        # The output above has jobid.{batch,extern,0} steps which are not needed.
+        # We will filter them out using ask command
         cmd = (
-            f'sacct -j {job_ids} -M {machine} --format="JobID,JobName,Elapsed,TimeLimit,AllocCPUS" -n '
-            + "|awk '{$1=$1} NF==5'"
+            f'sacct -j {job_ids} -M {machine} --format="JobID,Elapsed,TimeLimit,AllocCPUS" -n '
+            + "|awk '{$1=$1} NF==4'"  # squash whitespaces and select lines with 4 fields
         )
         sacct_output = subprocess.check_output(
             cmd,
@@ -177,19 +197,21 @@ def main():
         sacct_lines = sacct_output.decode().splitlines()
         assert len(sacct_lines) == len(
             machine_jobs[machine]
-        ), f"Something is wrong:  {len(sacct_lines)} {len(machine_jobs[machine])} {cmd}"  # make sure the command returned the output we want
+        ), f": {cmd}\nReturned incorrect number of records {len(sacct_lines)}, expected {len(machine_jobs[machine])}"
         for line in sacct_lines:
             job_info = line.split()
-            assert len(job_info) == 5
-            job_id, _, time_used, time_requested, num_cpus = job_info
-            assert job_id in machine_jobs[machine]
+            assert len(job_info) == 4, f"Should have exactly 4 fields: {line}"
+            job_id, time_used, time_requested, num_cpus = job_info
+            assert (
+                job_id in machine_jobs[machine]
+            ), f"Job ID {job_id} not found in the list of jobs for {machine}"
             run_name, proc_type_str = jobs_from_db[job_id]
             # Determine if it's a MEDIAN event (based on run_name)
             is_median_event = "_REL" not in run_name  # otherwise, it is a realization
 
             num_rels = realization_numbers.get(run_name, 0) if is_median_event else 0
             # we don't need to consider realisations for VM_GEN or INSTALL_FAULT
-            num_rels = 0 if proc_type_str in ["VM_GEN", "INSTALL_FAULT"] else num_rels
+            num_rels = 0 if proc_type_str in MEDIAN_ONLY_PROCS else num_rels
 
             # Convert time_used time to seconds
             time_used_seconds = convert_time_used_to_seconds(time_used)
@@ -208,17 +230,23 @@ def main():
                     "time_used": time_used,
                     "cpu_seconds_used": cpu_seconds_used,
                     "num_rels": num_rels,
-                    "cpu_seconds_need_for_all_rels": cpu_seconds_used*num_rels
+                    "cpu_seconds_need_for_all_rels": cpu_seconds_used * num_rels,
                 }
             )
 
     # Create a DataFrame from the list of dictionaries
     df = pd.DataFrame(data_list)
-    df.sort_values(['run_name','proc_type'], inplace=True)
+    df.sort_values(["run_name", "proc_type"], inplace=True)
     # Write to a CSV file
     df.to_csv(args.outfile, index=False)
 
     print(f"CSV file {args.outfile} created successfully!")
+    for machine in machines:
+        machine_df = df[df["machine"] == machine]
+        total = machine_df["cpu_seconds_need_for_all_rels"].sum()
+        print(
+            f"Total CPU hours needed for all realisations on {machine} : {total/3600:.2f} hours"
+        )
 
 
 if __name__ == "__main__":

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -11,6 +11,7 @@ This script is also useful to assess the quality of wall clock time estimation. 
 different from the time used, it may indicate that the wall clock time estimation method needs to be improved.
 
 """
+
 import argparse
 from datetime import datetime, timedelta
 import pandas as pd
@@ -26,15 +27,23 @@ REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
 
 DEFAULT_OUTFILE = "est_vs_used_cpu_time.csv"
 
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Get estimated vs used CPU time for jobs in the database"
     )
-    parser.add_argument("cs_root", type=Path, help="Path to the Cybershake root directory")
-    parser.add_argument("--list", type=Path, help="Path to the realization list file")
-    parser.add_argument("--update", type=Path, help="Path to the existing CSV file to update")
     parser.add_argument(
-        "--outfile", type=Path, help="Path to the output CSV file", default=DEFAULT_OUTFILE
+        "cs_root", type=Path, help="Path to the Cybershake root directory"
+    )
+    parser.add_argument("--list", type=Path, help="Path to the realization list file")
+    parser.add_argument(
+        "--update", type=Path, help="Path to the existing CSV file to update"
+    )
+    parser.add_argument(
+        "--outfile",
+        type=Path,
+        help="Path to the output CSV file",
+        default=DEFAULT_OUTFILE,
     )
 
     return parser.parse_args()
@@ -101,7 +110,7 @@ def main():
     # Query the run data that has completed successfully
     cursor.execute(
         "SELECT run_name, proc_type, job_id FROM state WHERE status = 5 AND proc_type != 20"
-    ) # status 5 is for the completed jobs. proc_type 20 is for NO_VM_PERT which has no job_id
+    )  # status 5 is for the completed jobs. proc_type 20 is for NO_VM_PERT which has no job_id
 
     rows = cursor.fetchall()
 
@@ -123,7 +132,9 @@ def main():
                 (row["run_name"], REVERSE_PROCESS_TYPE[row["proc_type"]]): row["job_id"]
                 for _, row in existing_df.iterrows()
             }
-            print(f"Record found in {args.update} : {len(jobs_from_csv.keys())} entries")
+            print(
+                f"Record found in {args.update} : {len(jobs_from_csv.keys())} entries"
+            )
 
     jobs_from_db = {(row[0], row[1]): row[2] for row in rows}
     print(f"Record found in DB : {len(jobs_from_db.keys())} entries")
@@ -166,7 +177,7 @@ def main():
         # Convert time_used time to seconds
         time_used_seconds = convert_time_used_to_seconds(time_used)
 
-        # Calculate CPU-seconds used 
+        # Calculate CPU-seconds used
         cpu_seconds_used = time_used_seconds * int(num_cpus)
 
         data_list.append(

--- a/workflow/automation/estimation/get_est_vs_used_cputime.py
+++ b/workflow/automation/estimation/get_est_vs_used_cputime.py
@@ -1,31 +1,59 @@
+"""
+Collect estimated vs used CPU time for Cybershake-styled runs
+
+This is particularly useful to accurately determine the estimated core hours for the entire set of Cybershake-styled
+simulations. One can run the MEDIAN simulations only, and then run this script to collect the estimated core hours and
+the cpu time actually used.
+By multiplying the time_used by the number of realisations that is (optionally) supplied with --list argument,
+we can accurately estimate the total core hours required to run the entire set of simulations.
+
+This script is also useful to assess the quality of wall clock time estimation. If the estimated time is significantly
+different from the time used, it may indicate that the wall clock time estimation method needs to be improved.
+
+"""
+import argparse
+from datetime import datetime, timedelta
+import pandas as pd
+from pathlib import Path
 import sqlite3
 import subprocess
-import pandas as pd
-import argparse
+
 from qcore.constants import ProcessType
-from datetime import datetime, timedelta
-from pathlib import Path
+from qcore import simulation_structure
 
 PROCESS_TYPE = dict([(proc.value, proc.name) for proc in ProcessType])
 REVERSE_PROCESS_TYPE = {name: value for value, name in PROCESS_TYPE.items()}
 
-DEFAULT_OUTCSV = "est_vs_used_cpu_time.csv"
-
+DEFAULT_OUTFILE = "est_vs_used_cpu_time.csv"
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Generate CSV data from SQLite and SLURM"
+        description="Get estimated vs used CPU time for jobs in the database"
     )
-    parser.add_argument("--list", help="Path to the realization list file")
-    parser.add_argument("--update", help="Path to the existing CSV file to update")
+    parser.add_argument("cs_root", type=Path, help="Path to the Cybershake root directory")
+    parser.add_argument("--list", type=Path, help="Path to the realization list file")
+    parser.add_argument("--update", type=Path, help="Path to the existing CSV file to update")
     parser.add_argument(
-        "--outfile", help="Path to the output CSV file", default=DEFAULT_OUTCSV
+        "--outfile", type=Path, help="Path to the output CSV file", default=DEFAULT_OUTFILE
     )
 
     return parser.parse_args()
 
 
-def read_realization_list(list_file):
+def read_realization_list(list_file: Path) -> dict:
+    """
+    Read the realization list file and return a dictionary of event names and the number of realizations
+    Parameters
+    ----------
+    list_file : Path
+        Path to the realization list file
+
+    Returns
+    -------
+    realization_data : dict
+        A dictionary of event names and the number of realizations
+
+    """
     realization_data = {}
     with open(list_file, "r") as f:
         for line in f:
@@ -38,40 +66,56 @@ def read_realization_list(list_file):
     return realization_data
 
 
-def convert_elapsed_to_seconds(elapsed_str):
-    # Convert elapsed time from "hh:mm:ss" to total seconds
-    elapsed_time = datetime.strptime(elapsed_str, "%H:%M:%S")
-    elapsed_seconds = timedelta(
-        hours=elapsed_time.hour,
-        minutes=elapsed_time.minute,
-        seconds=elapsed_time.second,
+def convert_time_used_to_seconds(time_used_str: str) -> float:
+    """
+    Convert time_used time from "hh:mm:ss" to total seconds
+    Parameters
+    ----------
+    time_used_str : str
+        time_used time in "hh:mm:ss" format
+    Returns
+    -------
+    time_used_seconds : float
+        time_used time in seconds
+    """
+
+    time_used_time = datetime.strptime(time_used_str, "%H:%M:%S")
+    time_used_seconds = timedelta(
+        hours=time_used_time.hour,
+        minutes=time_used_time.minute,
+        seconds=time_used_time.second,
     ).total_seconds()
-    return elapsed_seconds
+    return time_used_seconds
 
 
 def main():
     args = parse_args()
+    args.cs_root.is_dir() or exit(f"{args.cs_root} is not a directory")
+    if args.list is None:
+        args.list = simulation_structure.get_cybershake_list(args.cs_root)
 
     # Connect to the SQLite database
-    conn = sqlite3.connect("slurm_mgmt.db")
+    conn = sqlite3.connect(simulation_structure.get_mgmt_db(args.cs_root))
     cursor = conn.cursor()
 
-    # Query the relevant data
+    # Query the run data that has completed successfully
     cursor.execute(
         "SELECT run_name, proc_type, job_id FROM state WHERE status = 5 AND proc_type != 20"
-    )
+    ) # status 5 is for the completed jobs. proc_type 20 is for NO_VM_PERT which has no job_id
+
     rows = cursor.fetchall()
 
-    # Initialize a list to add
+    # Initialize a list to add the data to
     data_list = []
 
     # Read realization data from the list file
-    realization_data = read_realization_list(args.list) if args.list else {}
+    realization_data = read_realization_list(args.list) if args.list.exists() else {}
 
     jobs_from_csv = {}
     existing_df = None
 
     if args.update is not None:
+        # Read the existing CSV file
         args.update = Path(args.update)
         if args.update.exists():
             existing_df = pd.read_csv(args.update)
@@ -79,9 +123,9 @@ def main():
                 (row["run_name"], REVERSE_PROCESS_TYPE[row["proc_type"]]): row["job_id"]
                 for _, row in existing_df.iterrows()
             }
+            print(f"Record found in {args.update} : {len(jobs_from_csv.keys())} entries")
 
     jobs_from_db = {(row[0], row[1]): row[2] for row in rows}
-    print(f"Record found in {args.update} : {len(jobs_from_csv.keys())} entries")
     print(f"Record found in DB : {len(jobs_from_db.keys())} entries")
 
     jobs_to_add_dict = {
@@ -90,17 +134,15 @@ def main():
             set(jobs_from_db.keys()) - set(jobs_from_csv.keys())
         )
     }
-
     print(f"Records to add to the CSV: {jobs_to_add_dict}")
 
     # Iterate over job_ids
-    #    for run_name, proc_type_str,job_id in jobs_to_add_dict.items():
     for (run_name, proc_type_str), job_id in jobs_to_add_dict.items():
 
         assert job_id is not None, f"{run_name} {proc_type_str}"
         # Execute sacct command
         for machine in ["maui", "mahuika"]:
-            cmd = f'sacct -j {job_id} -M {machine} --format="JobName,Elapsed,TimeLimit,AllocCPUS"'
+            cmd = f'sacct -j {job_id} -M {machine} --format="JobName,time_used,time_requested,AllocCPUS"'
             sacct_output = subprocess.check_output(
                 cmd,
                 shell=True,
@@ -111,34 +153,31 @@ def main():
 
         assert (
             len(sacct_lines) >= 3
-        ), f"{job_id} {sacct_lines} {cmd}"  # make sure the command returned the output we want
+        ), f"Something is wrong:  {job_id} {sacct_lines} {cmd}"  # make sure the command returned the output we want
 
         # Extract relevant info from the first row containing numbers
-        try:
-            job_info = sacct_lines[2].split()
-        except IndexError:
-            raise
-        elapsed, timelimit, alloc_cpus = job_info[1], job_info[2], job_info[3]
+        job_info = sacct_lines[2].split()
+        time_used, time_requested, num_cpus = job_info[1], job_info[2], job_info[3]
 
-        # Determine if it's an event (based on run_name)
-        is_event = "_REL" not in run_name  # otherwise, it is a realization
-        num_rels = realization_data.get(run_name, None) if is_event else None
+        # Determine if it's a MEDIAN event (based on run_name)
+        is_median_event = "_REL" not in run_name  # otherwise, it is a realization
+        num_rels = realization_data.get(run_name, None) if is_median_event else None
 
-        # Convert elapsed time to seconds
-        elapsed_seconds = convert_elapsed_to_seconds(elapsed)
+        # Convert time_used time to seconds
+        time_used_seconds = convert_time_used_to_seconds(time_used)
 
-        # Calculate Corehours_used
-        coreseconds_used = elapsed_seconds * int(alloc_cpus)
+        # Calculate CPU-seconds used 
+        cpu_seconds_used = time_used_seconds * int(num_cpus)
 
         data_list.append(
             {
                 "run_name": run_name,
                 "proc_type": proc_type_str,
                 "job_id": job_id,
-                "CPUs_used": alloc_cpus,
-                "Time_requested": timelimit,
-                "Time_used": elapsed,
-                "Coreseconds_used": coreseconds_used,
+                "num_cpus": num_cpus,
+                "time_requested": time_requested,
+                "time_used": time_used,
+                "cpu_seconds_used": cpu_seconds_used,
                 "num_rels": num_rels,
             }
         )


### PR DESCRIPTION
I want to add this script to estimation tool kit in the workflow. The current wall-clock estimation is not very accurate, and makes it difficult to estimate the total core hours to run a Cybershake-styled large set of simulations. We also don't collect actual CPU time spent, and losing the crucial information of resource usage as well as the opportunity to improve the estimation quality.

This script will interact with SLURM (using sacct command, `-n` removes the header), 
```
$ sacct -j 4088784,4088640 --format="JobID,Elapsed,TimeLimit,AllocCPUS" -n
4088640        02:10:42   08:17:00        160
4088640.bat+   02:10:42                    80
4088640.ext+   02:10:42                   160
4088640.0      02:10:06                   160
4088784        00:03:38   00:30:00         80
4088784.bat+   00:03:38                    80
4088784.ext+   00:03:38                    80
 4088784.0      00:03:19                    80
```
This command gives more than we need - after we remove lines for steps of a job (.batch, .external, .0), we have
```
4088640        02:10:42   08:17:00        160
4088784        00:03:38   00:30:00         80
```
Here, 02:10:42 and 00:03:38 correspond to the CPU time used.
Wall clock time requested were 08:17:00 and 00:30:00 respectively. 160 and 80 mean the number of CPUs.

This script will consult SQLite3 DB, and collect all "completed" jobs, then query with "sacct" command to collect the estimated/actual resource usage, then create a CSV file.

Example run:
```
(python3_maui) baes@maui02: /nesi/nobackup/nesi00213/RunFolder/Cybershake/v24p6$ python $gmsim/workflow/workflow/automation/estimation/get_est_vs_used_cputime.py . list_crustal.txt 
Record found in DB : 4302 entries
CSV file est_vs_used_cpu_time.csv created successfully!
Total CPU hours needed for all realisations on maui : 3386491.20 hours
Total CPU hours needed for all realisations on mahuika : 5386.97 hours
```
