### PR TITLE
params.FD_STATLIST->params['FD_STATLIST']

### DIFF
--- a/workflow/automation/templates/sim_im_calc.sl.template
+++ b/workflow/automation/templates/sim_im_calc.sl.template
@@ -50,7 +50,7 @@ if [[ $res == 0 ]]; then
         mkdir {{sim_dir}}/ch_log
     fi
 
-    fd_name=`python -c "from workflow.automation import sim_params; params = sim_params.load_sim_params('{{sim_dir}}/sim_params.yaml'); print(params.FD_STATLIST)"`
+    fd_name=`python -c "from workflow.automation import sim_params; params = sim_params.load_sim_params('{{sim_dir}}/sim_params.yaml'); print(params['FD_STATLIST'])"`
     fd_count=`cat $fd_name | wc -l`
     pSA_count=`cat {{sim_dir}}/IM_calc/{{realisation_name}}.csv | head -n 1 | grep -o pSA | wc -l`
 


### PR DESCRIPTION
This must have been around sometime, but only noticed today.

`load_sim_params()` returns a dictionary, and we no longer support the dictionary values accessed like an object attribute.

`params.FD_STATLIST` causes this:


```
>>> params.FD_STATLIST
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'dict' object has no attribute 'FD_STATLIST'

```