### PR TITLE
Skip e3d.par when moving tmp files

### DIFF
--- a/workflow/automation/templates/run_emod3d.sl.template
+++ b/workflow/automation/templates/run_emod3d.sl.template
@@ -52,5 +52,8 @@ else
     echo "Completion test failed, moving all files to $backup_directory"
     echo "Failure reason: $res"
     mkdir -p $backup_directory
-    mv {{sim_dir}}/LF/* $backup_directory
+    shopt -s extglob #enable !() option used below
+    mv {{sim_dir}}/LF/!(e3d.par|OutBin/e3d.par) $backup_directory # leave e3d.par alone in case we need to restart this run
+    cp {{sim_dir}}/LF/e3d.par $backup_directory
+
 fi


### PR DESCRIPTION
When EMOD3D fails, the slurm/PBS script relocate incomplete output files to a temporary directory for later debug.
However, it also moves e3d.par, which will make the restart attempt futile as it will fail instantly if e3d.par is missing.

This change hopefully fixes this issue