### PR TITLE
Use 1 core for SRF_GEN

### DIFF
--- a/workflow/automation/org/nesi/srf_gen.sl
+++ b/workflow/automation/org/nesi/srf_gen.sl
@@ -7,9 +7,6 @@
 #SBATCH --time=01:00:00
 #SBATCH --cpus-per-task=1
 
-echo $CUR_ENV
-echo $CUR_HPC
-
 # Make sure we use the correct Python and environment on Mahuika
 source $CUR_ENV/workflow/workflow/environments/helper_functions/activate_env.sh $CUR_ENV "mahuika"
 

--- a/workflow/automation/org/nesi/srf_gen.sl
+++ b/workflow/automation/org/nesi/srf_gen.sl
@@ -5,11 +5,13 @@
 
 #SBATCH --job-name=SRF_GEN
 #SBATCH --time=01:00:00
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=1
 
-if [[ -n ${CUR_ENV} && ${CUR_HPC} != "mahuika" ]]; then
-    source $CUR_ENV/workflow/workflow/environments/helper_functions/activate_env.sh $CUR_ENV "mahuika"
-fi
+echo $CUR_ENV
+echo $CUR_HPC
+
+# Make sure we use the correct Python and environment on Mahuika
+source $CUR_ENV/workflow/workflow/environments/helper_functions/activate_env.sh $CUR_ENV "mahuika"
 
 REL_FILEPATH=${1:?REL_FILEPATH argument missing}
 MGMT_DB_LOC=${2:?MGMT_DB_LOC argument missing}


### PR DESCRIPTION
We always use 1 core for SRF_GEN, but incorrectly (and wastefully) requested 32!!

Also note that this job is meant to be submitted to mahuika, and it is submitted without `--export=ALL` option.
This is correct as we may be submitting the job from Maui, and we don't want to enforce its environment to Mahuika.
However, when a Mahuika compute node receives this job, it doesn't know which environment it is supposed to use.
Previously we had an IF block and only activated the environment when the job was submitted from Maui. 

Removal of this IF block will ensure the job can be submitted from any machine, and the correct Python environment is used.