### PR TITLE
Explicitly disable read_restart if restart is not intended

### DIFF
--- a/workflow/automation/templates/run_emod3d.sl.template
+++ b/workflow/automation/templates/run_emod3d.sl.template
@@ -53,8 +53,8 @@ else
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_LF"
     echo "Completion test failed, moving all files to $backup_directory"
     echo "Failure reason: $res"
-    mv {{sim_dir}}/LF $backup_directory
-    mkdir -p {{sim_dir}}/LF/OutBin # create LF directory
-    cp $backup_directory/e3d.par {{sim_dir}}/LF/ # bring back e3d.par
-
+    mkdir -p $backup_directory
+    mv {{sim_dir}}/LF/* $backup_directory
+    mkdir -p {{sim_dir}}/LF # create LF directory
+    cp $backup_directory/e3d.par {{sim_dir}}/LF # bring back e3d.par
 fi

--- a/workflow/automation/templates/run_emod3d.sl.template
+++ b/workflow/automation/templates/run_emod3d.sl.template
@@ -52,8 +52,8 @@ else
     echo "Completion test failed, moving all files to $backup_directory"
     echo "Failure reason: $res"
     mkdir -p $backup_directory
-    shopt -s extglob #enable !() option used below
-    mv {{sim_dir}}/LF/!(e3d.par|OutBin/e3d.par) $backup_directory # leave e3d.par alone in case we need to restart this run
-    cp {{sim_dir}}/LF/e3d.par $backup_directory
+    mv {{sim_dir}}/LF $backup_directory
+    mkdir -p {{sim_dir}}/LF # create LF directory
+    cp $backup_directory/e3d.par {{sim_dir}}/LF # bring back e3d.par
 
 fi

--- a/workflow/automation/templates/run_emod3d.sl.template
+++ b/workflow/automation/templates/run_emod3d.sl.template
@@ -8,7 +8,9 @@ SUCCESS_CODE=0
 
 if [[ -d "{{sim_dir}}/LF/Restart" ]] && [[ `ls -1 {{sim_dir}}/LF/Restart | wc -l` != $SUCCESS_CODE ]]; then
     echo "Checkpointed run found, attempting to resume from checkpoint"
-    sed -i 's/read_restart=.*/read_restart="1"/' {{sim_dir}}/LF/e3d.par
+    sed -i 's/read_restart=.*/read_restart=1/' {{sim_dir}}/LF/e3d.par
+else
+    sed -i 's/read_restart=.*/read_restart=0/' {{sim_dir}}/LF/e3d.par
 fi
 
 timestamp=`date +%Y%m%d_%H%M%S`
@@ -51,9 +53,8 @@ else
     backup_directory="$nobackup/tmp/$USER/""$SLURM_JOB_ID""_{{srf_name}}_LF"
     echo "Completion test failed, moving all files to $backup_directory"
     echo "Failure reason: $res"
-    mkdir -p $backup_directory
     mv {{sim_dir}}/LF $backup_directory
-    mkdir -p {{sim_dir}}/LF # create LF directory
-    cp $backup_directory/e3d.par {{sim_dir}}/LF # bring back e3d.par
+    mkdir -p {{sim_dir}}/LF/OutBin # create LF directory
+    cp $backup_directory/e3d.par {{sim_dir}}/LF/ # bring back e3d.par
 
 fi


### PR DESCRIPTION
Recent change kept e3d.par in LF directory by skipping it during "mv" operation. 
https://github.com/ucgmsim/slurm_gm_workflow/commit/c51afc89c7282a487ba7fbeec9edc5e937d88dea

While this change was tested ok and usually works fine, sometimes SLURM complains about mv with the  `!()` option (activated by `shopt -s extglob` ).  I haven't been able to work out why.

```
/var/spool/slurmd/job4209876/slurm_script: line 69: syntax error near unexpected token `('
/var/spool/slurmd/job4209876/slurm_script: line 69: `    mv /scale_wlg_nobackup/filesets/nobackup/nesi00213/RunFolder/Cybershake/v24p9/Runs/HikHBaymax/HikHBaymax_REL61/LF/!(e3d.par|OutBin/e3d.par) $backup_directory # leave e3d.par alone in case we need to restart this run'
```

I am not religious to the solution. In fact, the proposed solution here is more conventional and should be more reliable.

More importantly, I enforced read_restart=0, if restarting is not intended. 

Since we now re-use the e3d.par, depending on the run history, this field might have been previously updated to 1. If this field is 1, this forces EMOD3D to read LF/Restart folder. However if this is meant to be a fresh run and this field is accidentally 1, no such folder exists and EMOD3D will instantly fail.



