### PR TITLE
Support _REL100: Previously maximum was _REL99

### DIFF
--- a/workflow/automation/org/kisti/install_realisation.pbs
+++ b/workflow/automation/org/kisti/install_realisation.pbs
@@ -13,7 +13,7 @@ export SLURM_JOB_ID="${PBS_JOBID/.pbs/}"
 export SLURM_CPUS_PER_TASK=$(qstat $SLURM_JOB_ID -f | grep "used.ncpus" | cut -d"=" -f2 | bc)
 export SLURM_NNODES=$(qstat $SLURM_JOB_ID -f | grep "List.nodect" | cut -d"=" -f2 | bc)
 
-FAULT=$(echo $REL_NAME | cut -d"_" -f1)
+FAULT=$(echo ${REL_NAME/_REL*/})
 SIM_DIR=$MGMT_DB_LOC/Runs/$FAULT/$REL_NAME
 CH_LOG_FFP=$SIM_DIR/ch_log
 

--- a/workflow/automation/org/nesi/install_realisation.sl
+++ b/workflow/automation/org/nesi/install_realisation.sl
@@ -13,7 +13,7 @@ source $CUR_ENV/workflow/workflow/environments/helper_functions/activate_env.sh 
 REL_NAME=${1:?REL_NAME argument missing}
 SIMULATION_ROOT=${2:?SIMULATION_ROOT argument missing}
 
-FAULT=$(echo ${REL_NAME/_REL??/})
+FAULT=$(echo ${REL_NAME/_REL*/})
 SIM_DIR=$SIMULATION_ROOT/Runs/$FAULT/$REL_NAME
 CH_LOG_FFP=$SIM_DIR/ch_log
 


### PR DESCRIPTION
We usually give 2-digit REL number, REL01, .... REL99.
@sarahjaneneill wants to test 100 realisations and we have a rel name with 3-digit number like `3373091_REL100`

Unfortunately, 
`FAULT=$(echo ${REL_NAME/_REL??/})`

We get a FAULT name 3373091**0** (notice the extra 0), and the wrong FAULT leads to the install_realisation step test fail for _REL100 and higher.
