### PR TITLE
Update create_e3d.py

### DIFF
--- a/workflow/calculation/create_e3d.py
+++ b/workflow/calculation/create_e3d.py
@@ -136,6 +136,6 @@ def create_run_params(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("SIM_ROOT")
-    parser.parse_args()
-    create_run_params(parser.sim_root)
+    parser.add_argument("sim_root")
+    args = parser.parse_args()
+    create_run_params(args.sim_root)


### PR DESCRIPTION
The broken main function rendered `create_e3d.py` unusable as a standalone script to generate e3d.par. This code change resolves such an issue


