### PR TITLE
Correctly update sim_params.yaml if vm_pert is successful

### DIFF
--- a/workflow/automation/execution_scripts/cybershake_progress.py
+++ b/workflow/automation/execution_scripts/cybershake_progress.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Prints out the current cybershake status.
-"""
+"""Prints out the current cybershake status."""
 import argparse
 import json
 from pathlib import Path

--- a/workflow/automation/install_scripts/create_mgmt_db.py
+++ b/workflow/automation/install_scripts/create_mgmt_db.py
@@ -1,7 +1,7 @@
 """
 @author: jam335 - jason.motha@canterbury.ac.nz
 
-A script that creates a database and populates it with the status of 
+A script that creates a database and populates it with the status of
 each stage of the run
 """
 

--- a/workflow/automation/org/nesi/vm_pert.sl
+++ b/workflow/automation/org/nesi/vm_pert.sl
@@ -69,7 +69,7 @@ if [[ $pass == 0 ]]; then
 
     python $gmsim/workflow/workflow/automation/execution_scripts/add_to_mgmt_queue.py $MGMT_DB_LOC/mgmt_db_queue $REL_NAME VM_PERT completed $SLURM_JOB_ID --end_time "$end_time"
 
-    python -c "from qcore import utils;d=utils.load('${SIM_DIR}/sim_params.yaml');d['emod3d']['model_style']=3;d['emod3d']['pertbfile']='$OUT_DIR/$REL_NAME.pertb';utils.dump_yaml(d,'${SIM_DIR}/sim_params.yaml')"
+    python -c "from qcore import utils;d=utils.load_yaml('${SIM_DIR}/sim_params.yaml');d['emod3d']['model_style']=3;d['emod3d']['pertbfile']='$OUT_DIR/$REL_NAME.pertb';utils.dump_yaml(d,'${SIM_DIR}/sim_params.yaml')"
 
     if [[ ! -d $CH_LOG_FFP ]]; then
         mkdir $CH_LOG_FFP

--- a/workflow/calculation/verification/check_emod3d_subdomains.py
+++ b/workflow/calculation/verification/check_emod3d_subdomains.py
@@ -1,7 +1,7 @@
 """
 Contains functions related to the calculation of emod3d subdomain boundaries.
 Functions ported from C contain a number of calls to np.int32 and np.float32 calls to emulate single precision integer and floating point behaviour.
-Code ported from emod3d v3.0.8 misc.c. This is consistent with v3.0.7. 
+Code ported from emod3d v3.0.8 misc.c. This is consistent with v3.0.7.
 While v3.0.4 uses long doubles in place of floats, this does not seem to practically increase the accuracy of calculation.
 This check is stricter than necessary as only on rows/columns with stations missing will cause issues when extracting the station waveforms.
 """


### PR DESCRIPTION
This commit (https://github.com/ucgmsim/slurm_gm_workflow/commit/ad9e688029453b8fbf81fe414669798aabc81e2a) was introduced to update sim_params.yaml upon a successful VM perturbation step. 

However, there is no such function load() and it has always failed. In the SLURM .err log. we have
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'qcore.utils' has no attribute 'load'

```
This error was not explicitly reported, and vm_pert step is marked as "completed".
As a result, emod3d is unaware of the presence of VM perturbation file and calculates without it. 
