### PR TITLE
Let master handle validate_end()

### DIFF
--- a/workflow/calculation/hf_sim.py
+++ b/workflow/calculation/hf_sim.py
@@ -514,8 +514,7 @@ if __name__ == "__main__":
                 e_dist[i].tofile(out)
                 vs.tofile(out)
 
-    # distribute work, must be sequential for optimisation,
-    # and for validation function above to be thread safe
+    # distribute work in a round-robin fashion across ranks for optimisation
     # if size=4, rank 0 takes [0,4,8...], rank 1 takes [1,5,9...], rank 2 takes [2,6,10...],
     # rank 3 takes [3,7,11...]
     work = stations_todo[rank::size]

--- a/workflow/calculation/hf_sim.py
+++ b/workflow/calculation/hf_sim.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
         except SystemExit as e:
             print(e, flush=True)
             # invalid arguments or -h
-            comm.Abort()
+            comm.Abort(1)
 
         if args.sim_bin is None:
             args.sim_bin = binary_version.get_hf_binmod(args.version)
@@ -381,7 +381,7 @@ if __name__ == "__main__":
                 logger.debug("Checkpoints found.")
                 initialise(check_only=True)
                 logger.error("HF Simulation already completed.")
-                comm.Abort()
+                comm.Abort(1)
             except AssertionError:
                 return
         # seems ok to continue simulation
@@ -504,7 +504,7 @@ if __name__ == "__main__":
 
             with open(f"hf_err_{idx_0}", "w") as e:
                 e.write(stderr)
-            comm.Abort()
+            comm.Abort(1)
 
         # write e_dist and vs to file
         with open(args.out_file, "r+b") as out:

--- a/workflow/calculation/hf_sim.py
+++ b/workflow/calculation/hf_sim.py
@@ -514,18 +514,6 @@ if __name__ == "__main__":
                 e_dist[i].tofile(out)
                 vs.tofile(out)
 
-    def validate_end(idx_n):
-        """
-        Verify filesize has been extended by the correct amount.
-        idx_n: position (starting at 1) of last station to be completed
-        """
-        try:
-            assert os.stat(args.out_file).st_size == head_total + idx_n * block_size
-        except AssertionError:
-            msg = f"Expected size: {head_total + idx_n * block_size} bytes (last stat idx: {idx_n}), actual {os.stat(args.out_file).st_size} bytes."
-            logger.error("Validation failed: {}".format(msg))
-            comm.Abort()
-
     # distribute work, must be sequential for optimisation,
     # and for validation function above to be thread safe
     # if size=4, rank 0 takes [0,4,8...], rank 1 takes [1,5,9...], rank 2 takes [2,6,10...],
@@ -551,19 +539,7 @@ if __name__ == "__main__":
             in_stats, 1, work_idx[s], v1d_path=v1d_path
         )  # passing in_stat with the seed adjustment work_idx[s]
 
-    if (
-        len(work_idx) > 0
-        and len(stations_todo_idx) > 0
-        and work_idx[-1] == stations_todo_idx[-1]
-    ):  # if this rank did the last station in the full list
-        validate_end(work_idx[-1] + 1)
-
     os.remove(in_stats)
-    print(
-        "Process {} of {} completed {} stations ({:.2f}).".format(
-            rank, size, work.size, MPI.Wtime() - t0
-        )
-    )
     logger.debug(
         "Process {} of {} completed {} stations ({:.2f}).".format(
             rank, size, work.size, MPI.Wtime() - t0
@@ -571,4 +547,12 @@ if __name__ == "__main__":
     )
     comm.Barrier()  # all ranks wait here until rank 0 arrives to announce all completed
     if is_master:
-        logger.debug("Simulation completed.")
+        actual_size = os.stat(args.out_file).st_size
+        if actual_size != file_size:
+            msg = f"CRITICAL: Final file size mismatch! Expected {file_size}, got {actual_size}"
+            print(msg, flush=True)
+            logger.error(msg)
+            comm.Abort(1)
+        else:
+            logger.debug("Simulation completed and size verified.")
+            print("✅ HF completed successfully", flush=True)


### PR DESCRIPTION
**The ISSUE**
The old code assumed that the rank processing the numerically highest station index (`work_idx[-1] == stations_todo_idx[-1]`) would inherently be the last rank to finish writing to the file.

In a multi-node environment, that is not guaranteed. Rank 35 might be assigned the very last station and finish it in 10 seconds. Meanwhile, Rank 2 might be assigned a complex station early in the list and take 15 seconds to finish.
Under the old logic, Rank 35 would finish, trigger `validate_end()`, and potentially pass or fail the size check while Rank 2 is still actively writing data to the middle of the file. 

Furthermore, if a rank triggered a validation error and exited silently without properly signaling the entire communicator, the surviving ranks would wait at the MPI barrier indefinitely until the Slurm allocation ran out, causing a resource-wasting "zombie" deadlock. (wasting core hours until it hits walltime!)

**Solution**
1. Removed the isolated `validate_end()` function from the worker loop.
2. Relied on the existing `comm.Barrier()` to ensure all ranks have completely finished their calculations and I/O.
3. Delegated the final file size validation to the Master Rank (`is_master`) strictly after the barrier is lifted.
4. Added `flush=True` to standard output prints to ensure timely log delivery in Slurm `.out` files.
5. Implemented `comm.Abort(1)` for critical file size mismatches. ***IMPORTANT*** When paired with the `srun --quit-on-interrupt --kill-on-bad-exit=1` flags in the submission wrappers, this guarantees that a validation failure acts as a cluster-wide kill switch, instantly terminating all tasks across all nodes and preventing hung jobs.

This ensures deterministic file validation, prevents premature exits, and guarantees clean job failures without wasting compute allocation.